### PR TITLE
Implement FsEqual CLI and TUI comparison tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+**/bin/
+**/obj/

--- a/src/FsEqual/Commands/CompareCommand.cs
+++ b/src/FsEqual/Commands/CompareCommand.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using FsEqual.Core;
+using FsEqual.Reporting;
+using FsEqual.Interactive;
+
+namespace FsEqual.Commands;
+
+public sealed class CompareCommand : AsyncCommand<CompareCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<LEFT>")]
+        public string Left { get; init; } = string.Empty;
+
+        [CommandArgument(1, "<RIGHT>")]
+        public string Right { get; init; } = string.Empty;
+
+        [CommandOption("-t|--threads <INT>")]
+        public int? Threads { get; init; }
+
+        [CommandOption("-a|--algo <ALGO>")]
+        public string Algorithm { get; init; } = "crc32";
+
+        [CommandOption("-m|--mode <MODE>")]
+        public string Mode { get; init; } = "quick";
+
+        [CommandOption("-i|--ignore <GLOB>")]
+        public string[] Ignore { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--case-sensitive")]
+        public bool CaseSensitive { get; init; }
+
+        [CommandOption("--follow-symlinks")]
+        public bool FollowSymlinks { get; init; }
+
+        [CommandOption("--mtime-tolerance <SECONDS>")]
+        public double? MTimeTolerance { get; init; }
+
+        [CommandOption("-v|--verbosity <LEVEL>")]
+        public string Verbosity { get; init; } = "info";
+
+        [CommandOption("--json <PATH>")]
+        public string? JsonOutput { get; init; }
+
+        [CommandOption("--summary <PATH>")]
+        public string? SummaryOutput { get; init; }
+
+        [CommandOption("--no-progress")]
+        public bool NoProgress { get; init; }
+
+        [CommandOption("--interactive")]
+        public bool Interactive { get; init; }
+
+        [CommandOption("--timeout <SECONDS>")]
+        public int? TimeoutSeconds { get; init; }
+
+        [CommandOption("--fail-on <KIND>")]
+        public string FailOn { get; init; } = "diff";
+
+        [CommandOption("--profile <NAME>")]
+        public string? Profile { get; init; }
+
+        [CommandOption("--config <PATH>")]
+        public string? Config { get; init; }
+    }
+
+    public override ValidationResult Validate(CommandContext context, Settings settings)
+    {
+        if (string.IsNullOrWhiteSpace(settings.Left) || string.IsNullOrWhiteSpace(settings.Right))
+        {
+            return ValidationResult.Error("Both <LEFT> and <RIGHT> paths must be provided.");
+        }
+
+        if (!Directory.Exists(settings.Left))
+        {
+            return ValidationResult.Error($"Left path '{settings.Left}' does not exist.");
+        }
+
+        if (!Directory.Exists(settings.Right))
+        {
+            return ValidationResult.Error($"Right path '{settings.Right}' does not exist.");
+        }
+
+        if (settings.Threads.HasValue && settings.Threads.Value <= 0)
+        {
+            return ValidationResult.Error("--threads must be a positive integer.");
+        }
+
+        if (settings.TimeoutSeconds.HasValue && settings.TimeoutSeconds <= 0)
+        {
+            return ValidationResult.Error("--timeout must be positive.");
+        }
+
+        return ValidationResult.Success();
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var options = new ComparisonOptions
+        {
+            LeftRoot = Path.GetFullPath(settings.Left),
+            RightRoot = Path.GetFullPath(settings.Right),
+            Mode = ParseMode(settings.Mode),
+            HashAlgorithm = ParseAlgorithm(settings.Algorithm),
+            Threads = settings.Threads,
+            CaseSensitive = settings.CaseSensitive,
+            FollowSymlinks = settings.FollowSymlinks,
+            MTimeTolerance = TimeSpan.FromSeconds(settings.MTimeTolerance ?? 0),
+            IgnoreGlobs = settings.Ignore.ToImmutableArray(),
+            NoProgress = settings.NoProgress || settings.Interactive,
+            JsonOutputPath = settings.JsonOutput,
+            SummaryOutputPath = settings.SummaryOutput,
+            Interactive = settings.Interactive,
+            TimeoutSeconds = settings.TimeoutSeconds,
+            FailOn = ParseFailOn(settings.FailOn),
+            ProfileName = settings.Profile,
+            ConfigPath = settings.Config,
+            Verbosity = ParseVerbosity(settings.Verbosity)
+        };
+
+        var service = new ComparisonService(options, AnsiConsole.Console);
+        var result = await service.ExecuteAsync(CancellationToken.None);
+
+        if (settings.Interactive)
+        {
+            var interactive = new InteractiveSession(options, result, AnsiConsole.Console);
+            interactive.Run();
+        }
+        else
+        {
+            var reporter = new ConsoleReporter(AnsiConsole.Console, options.Verbosity);
+            reporter.Render(result, options);
+        }
+
+        if (!settings.Interactive)
+        {
+            var exporter = new ReportExporter();
+            await exporter.ExportAsync(result, options, AnsiConsole.Console);
+        }
+
+        var exitCode = DetermineExitCode(result, options.FailOn);
+        return exitCode;
+    }
+
+    private static ComparisonMode ParseMode(string value)
+    {
+        var normalized = value.ToLowerInvariant();
+        if (normalized == "quick")
+        {
+            return ComparisonMode.Quick;
+        }
+        if (normalized == "hash")
+        {
+            return ComparisonMode.Hash;
+        }
+
+        throw new InvalidOperationException($"Unknown comparison mode '{value}'.");
+    }
+
+    private static HashAlgorithmKind ParseAlgorithm(string value)
+    {
+        var normalized = value.ToLowerInvariant();
+        return normalized switch
+        {
+            "crc32" => HashAlgorithmKind.Crc32,
+            "md5" => HashAlgorithmKind.Md5,
+            "sha256" => HashAlgorithmKind.Sha256,
+            "xxh64" => HashAlgorithmKind.Xxh64,
+            _ => throw new InvalidOperationException($"Unknown hash algorithm '{value}'.")
+        };
+    }
+
+    private static FailOnCondition ParseFailOn(string value)
+    {
+        var normalized = value.ToLowerInvariant();
+        return normalized switch
+        {
+            "any" => FailOnCondition.Any,
+            "diff" => FailOnCondition.Diff,
+            "error" => FailOnCondition.Error,
+            _ => throw new InvalidOperationException($"Unknown fail-on option '{value}'.")
+        };
+    }
+
+    private static VerbosityLevel ParseVerbosity(string value)
+    {
+        var normalized = value.ToLowerInvariant();
+        return normalized switch
+        {
+            "trace" => VerbosityLevel.Trace,
+            "debug" => VerbosityLevel.Debug,
+            "info" => VerbosityLevel.Info,
+            "warn" => VerbosityLevel.Warn,
+            "error" => VerbosityLevel.Error,
+            _ => throw new InvalidOperationException($"Unknown verbosity '{value}'.")
+        };
+    }
+
+    private static int DetermineExitCode(ComparisonResult result, FailOnCondition failOn)
+    {
+        var hasErrors = result.Summary.Errors > 0 || result.Errors.Length > 0;
+        var hasDifferences = result.Summary.DifferentFiles > 0 || result.Summary.MissingLeft > 0 || result.Summary.MissingRight > 0;
+
+        if (hasErrors)
+        {
+            return 2;
+        }
+
+        if (failOn != FailOnCondition.Error && hasDifferences)
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/src/FsEqual/Core/ComparisonMode.cs
+++ b/src/FsEqual/Core/ComparisonMode.cs
@@ -1,0 +1,7 @@
+namespace FsEqual.Core;
+
+public enum ComparisonMode
+{
+    Quick,
+    Hash
+}

--- a/src/FsEqual/Core/ComparisonOptions.cs
+++ b/src/FsEqual/Core/ComparisonOptions.cs
@@ -1,0 +1,34 @@
+using System.Collections.Immutable;
+
+namespace FsEqual.Core;
+
+public sealed record ComparisonOptions
+{
+    public required string LeftRoot { get; init; }
+    public required string RightRoot { get; init; }
+    public ComparisonMode Mode { get; init; } = ComparisonMode.Quick;
+    public HashAlgorithmKind HashAlgorithm { get; init; } = HashAlgorithmKind.Crc32;
+    public int? Threads { get; init; }
+    public bool CaseSensitive { get; init; }
+    public bool FollowSymlinks { get; init; }
+    public TimeSpan MTimeTolerance { get; init; } = TimeSpan.Zero;
+    public ImmutableArray<string> IgnoreGlobs { get; init; } = ImmutableArray<string>.Empty;
+    public bool NoProgress { get; init; }
+    public string? JsonOutputPath { get; init; }
+    public string? SummaryOutputPath { get; init; }
+    public bool Interactive { get; init; }
+    public int? TimeoutSeconds { get; init; }
+    public FailOnCondition FailOn { get; init; } = FailOnCondition.Diff;
+    public string? ProfileName { get; init; }
+    public string? ConfigPath { get; init; }
+    public VerbosityLevel Verbosity { get; init; } = VerbosityLevel.Info;
+}
+
+public enum VerbosityLevel
+{
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error
+}

--- a/src/FsEqual/Core/ComparisonResult.cs
+++ b/src/FsEqual/Core/ComparisonResult.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+
+namespace FsEqual.Core;
+
+public sealed record ComparisonResult
+{
+    public required ComparisonSummary Summary { get; init; }
+    public required ImmutableArray<DifferenceRecord> Differences { get; init; }
+    public required ComparisonNode RootNode { get; init; }
+    public required ImmutableArray<string> Errors { get; init; }
+    public TimeSpan Elapsed { get; init; }
+}
+
+public sealed record ComparisonSummary
+{
+    public int TotalFiles { get; init; }
+    public int TotalDirectories { get; init; }
+    public int EqualFiles { get; init; }
+    public int DifferentFiles { get; init; }
+    public int MissingLeft { get; init; }
+    public int MissingRight { get; init; }
+    public int Errors { get; init; }
+}
+
+public sealed record DifferenceRecord
+{
+    public required DifferenceType Type { get; init; }
+    public required string Path { get; init; }
+    public long? LeftSize { get; init; }
+    public long? RightSize { get; init; }
+    public string? Algorithm { get; init; }
+    public string? Reason { get; init; }
+}
+
+public sealed record ComparisonNode
+{
+    public required string Name { get; init; }
+    public required string RelativePath { get; init; }
+    public required bool IsDirectory { get; init; }
+    public required DifferenceType? Status { get; init; }
+    public required ImmutableArray<ComparisonNode> Children { get; init; }
+    public int EqualCount { get; init; }
+    public int DiffCount { get; init; }
+    public int MissingCount { get; init; }
+    public int ErrorCount { get; init; }
+    public FileMetadata? LeftMetadata { get; init; }
+    public FileMetadata? RightMetadata { get; init; }
+}
+
+public sealed record FileMetadata
+{
+    public long Size { get; init; }
+    public DateTime LastWriteTimeUtc { get; init; }
+    public string? Hash { get; init; }
+}

--- a/src/FsEqual/Core/ComparisonService.cs
+++ b/src/FsEqual/Core/ComparisonService.cs
@@ -1,0 +1,455 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Spectre.Console;
+
+namespace FsEqual.Core;
+
+public sealed class ComparisonService
+{
+    private readonly ComparisonOptions _options;
+    private readonly IAnsiConsole _console;
+
+    public ComparisonService(ComparisonOptions options, IAnsiConsole? console = null)
+    {
+        _options = options;
+        _console = console ?? AnsiConsole.Console;
+    }
+
+    public async Task<ComparisonResult> ExecuteAsync(CancellationToken cancellationToken)
+    {
+        using var timeoutCts = _options.TimeoutSeconds is null
+            ? null
+            : new CancellationTokenSource(TimeSpan.FromSeconds(_options.TimeoutSeconds.Value));
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutCts?.Token ?? CancellationToken.None);
+
+        var token = linkedCts.Token;
+        var stopwatch = Stopwatch.StartNew();
+        var errors = new ConcurrentBag<string>();
+
+        FileSystemSnapshot leftSnapshot = default!;
+        FileSystemSnapshot rightSnapshot = default!;
+
+        async Task EnumerateAsync()
+        {
+            await Task.Run(() =>
+            {
+                leftSnapshot = FileSystemSnapshot.Create(_options.LeftRoot, _options.CaseSensitive, _options.FollowSymlinks, _options.IgnoreGlobs, token);
+                rightSnapshot = FileSystemSnapshot.Create(_options.RightRoot, _options.CaseSensitive, _options.FollowSymlinks, _options.IgnoreGlobs, token);
+            }, token);
+        }
+
+        if (_options.NoProgress)
+        {
+            await EnumerateAsync();
+        }
+        else
+        {
+            await _console.Status().StartAsync("Enumerating file system", async _ =>
+            {
+                await EnumerateAsync();
+            });
+        }
+
+        ImmutableDictionary<string, string?> leftHashes = ImmutableDictionary<string, string?>.Empty;
+        ImmutableDictionary<string, string?> rightHashes = ImmutableDictionary<string, string?>.Empty;
+
+        if (_options.Mode == ComparisonMode.Hash)
+        {
+            var hashComputer = new HashComputer(_options.HashAlgorithm);
+            var parallelOptions = new ParallelOptions
+            {
+                MaxDegreeOfParallelism = _options.Threads ?? Environment.ProcessorCount,
+                CancellationToken = token
+            };
+
+            async Task<ImmutableDictionary<string, string?>> ComputeAsync(string root, FileSystemSnapshot snapshot, string side)
+            {
+                return await Task.Run(() =>
+                {
+                    var results = new ConcurrentDictionary<string, string?>(snapshot.Comparer);
+                    Parallel.ForEach(snapshot.Entries.Values.Where(e => !e.IsDirectory), parallelOptions, entry =>
+                    {
+                        var absolutePath = Path.Combine(root, entry.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+                        try
+                        {
+                            var hash = hashComputer.ComputeHash(absolutePath, token);
+                            results[entry.RelativePath] = hash;
+                        }
+                        catch (Exception ex)
+                        {
+                            errors.Add($"{side}:{entry.RelativePath}: {ex.Message}");
+                            results[entry.RelativePath] = null;
+                        }
+                    });
+                    return results.ToImmutableDictionary();
+                }, token);
+            }
+
+            if (_options.NoProgress)
+            {
+                leftHashes = await ComputeAsync(_options.LeftRoot, leftSnapshot, "left");
+                rightHashes = await ComputeAsync(_options.RightRoot, rightSnapshot, "right");
+            }
+            else
+            {
+                await _console.Status().StartAsync("Hashing files", async _ =>
+                {
+                    leftHashes = await ComputeAsync(_options.LeftRoot, leftSnapshot, "left");
+                    rightHashes = await ComputeAsync(_options.RightRoot, rightSnapshot, "right");
+                });
+            }
+        }
+
+        var comparer = _options.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+        var allPaths = new SortedSet<string>(comparer);
+        foreach (var path in leftSnapshot.Paths)
+        {
+            allPaths.Add(path);
+        }
+        foreach (var path in rightSnapshot.Paths)
+        {
+            allPaths.Add(path);
+        }
+
+        var rootBuilder = new NodeBuilder("root", string.Empty, true, null);
+        var builders = new Dictionary<string, NodeBuilder>(comparer)
+        {
+            [string.Empty] = rootBuilder
+        };
+
+        NodeBuilder EnsureNode(string relativePath, bool isDirectory)
+        {
+            if (relativePath.Length == 0)
+            {
+                return rootBuilder;
+            }
+
+            if (!builders.TryGetValue(relativePath, out var existing))
+            {
+                var parentPath = Path.GetDirectoryName(relativePath.Replace('/', Path.DirectorySeparatorChar))?.Replace(Path.DirectorySeparatorChar, '/') ?? string.Empty;
+                var name = Path.GetFileName(relativePath.Replace('/', Path.DirectorySeparatorChar));
+                var parent = EnsureNode(parentPath, true);
+                existing = new NodeBuilder(name, relativePath, isDirectory, parent);
+                parent.Children.Add(existing);
+                builders[relativePath] = existing;
+            }
+            else if (isDirectory && !existing.IsDirectory)
+            {
+                existing.IsDirectory = true;
+            }
+
+            return existing;
+        }
+
+        var differences = ImmutableArray.CreateBuilder<DifferenceRecord>();
+        var summary = new SummaryBuilder();
+
+        foreach (var path in allPaths)
+        {
+            var leftExists = leftSnapshot.TryGet(path, out var leftEntry);
+            var rightExists = rightSnapshot.TryGet(path, out var rightEntry);
+            var isDirectory = leftEntry?.IsDirectory ?? rightEntry?.IsDirectory ?? false;
+            var node = EnsureNode(path, isDirectory);
+            node.LeftEntry = leftEntry;
+            node.RightEntry = rightEntry;
+
+            if (isDirectory)
+            {
+                summary.TotalDirectories++;
+                if (!leftExists)
+                {
+                    node.Status = DifferenceType.MissingLeft;
+                    differences.Add(new DifferenceRecord
+                    {
+                        Type = DifferenceType.MissingLeft,
+                        Path = path,
+                        Reason = "Directory missing on left"
+                    });
+                    summary.MissingLeft++;
+                }
+                else if (!rightExists)
+                {
+                    node.Status = DifferenceType.MissingRight;
+                    differences.Add(new DifferenceRecord
+                    {
+                        Type = DifferenceType.MissingRight,
+                        Path = path,
+                        Reason = "Directory missing on right"
+                    });
+                    summary.MissingRight++;
+                }
+                continue;
+            }
+
+            summary.TotalFiles++;
+
+            if (!leftExists)
+            {
+                node.Status = DifferenceType.MissingLeft;
+                node.RightMetadata = CreateMetadata(rightEntry!, rightHashes);
+                differences.Add(new DifferenceRecord
+                {
+                    Type = DifferenceType.MissingLeft,
+                    Path = path,
+                    RightSize = rightEntry!.Size,
+                    Reason = "File missing on left"
+                });
+                summary.MissingLeft++;
+                summary.DifferentFiles++;
+                continue;
+            }
+
+            if (!rightExists)
+            {
+                node.Status = DifferenceType.MissingRight;
+                node.LeftMetadata = CreateMetadata(leftEntry!, leftHashes);
+                differences.Add(new DifferenceRecord
+                {
+                    Type = DifferenceType.MissingRight,
+                    Path = path,
+                    LeftSize = leftEntry!.Size,
+                    Reason = "File missing on right"
+                });
+                summary.MissingRight++;
+                summary.DifferentFiles++;
+                continue;
+            }
+
+            node.LeftMetadata = CreateMetadata(leftEntry!, leftHashes);
+            node.RightMetadata = CreateMetadata(rightEntry!, rightHashes);
+
+            if (leftEntry!.IsDirectory != rightEntry!.IsDirectory)
+            {
+                node.Status = DifferenceType.TypeMismatch;
+                differences.Add(new DifferenceRecord
+                {
+                    Type = DifferenceType.TypeMismatch,
+                    Path = path,
+                    Reason = "Item types differ"
+                });
+                summary.DifferentFiles++;
+                continue;
+            }
+
+            if (leftEntry.Size != rightEntry.Size)
+            {
+                node.Status = DifferenceType.SizeMismatch;
+                differences.Add(new DifferenceRecord
+                {
+                    Type = DifferenceType.SizeMismatch,
+                    Path = path,
+                    LeftSize = leftEntry.Size,
+                    RightSize = rightEntry.Size,
+                    Reason = "File sizes differ"
+                });
+                summary.DifferentFiles++;
+                continue;
+            }
+
+            if (_options.Mode == ComparisonMode.Quick)
+            {
+                var delta = Math.Abs((leftEntry.LastWriteTimeUtc - rightEntry.LastWriteTimeUtc).TotalSeconds);
+                if (delta > _options.MTimeTolerance.TotalSeconds)
+                {
+                    node.Status = DifferenceType.TimestampMismatch;
+                    differences.Add(new DifferenceRecord
+                    {
+                        Type = DifferenceType.TimestampMismatch,
+                        Path = path,
+                        Reason = $"Timestamp differs by {delta:F1}s"
+                    });
+                    summary.DifferentFiles++;
+                }
+                else
+                {
+                    summary.EqualFiles++;
+                }
+                continue;
+            }
+
+            if (_options.Mode == ComparisonMode.Hash)
+            {
+                var leftHash = leftHashes.TryGetValue(path, out var l) ? l : null;
+                var rightHash = rightHashes.TryGetValue(path, out var r) ? r : null;
+                if (leftHash is null || rightHash is null)
+                {
+                    node.Status = DifferenceType.Error;
+                    differences.Add(new DifferenceRecord
+                    {
+                        Type = DifferenceType.Error,
+                        Path = path,
+                        Algorithm = _options.HashAlgorithm.ToString().ToLowerInvariant(),
+                        Reason = "Unable to compute hash"
+                    });
+                    summary.Errors++;
+                    continue;
+                }
+
+                if (!string.Equals(leftHash, rightHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    node.Status = DifferenceType.HashMismatch;
+                    differences.Add(new DifferenceRecord
+                    {
+                        Type = DifferenceType.HashMismatch,
+                        Path = path,
+                        LeftSize = leftEntry.Size,
+                        RightSize = rightEntry.Size,
+                        Algorithm = _options.HashAlgorithm.ToString().ToLowerInvariant(),
+                        Reason = "Hashes differ"
+                    });
+                    summary.DifferentFiles++;
+                }
+                else
+                {
+                    summary.EqualFiles++;
+                }
+            }
+        }
+
+        PopulateNodeStatistics(rootBuilder);
+
+        var summarySnapshot = summary.ToSummary();
+        summarySnapshot = summarySnapshot with { Errors = Math.Max(summarySnapshot.Errors, errors.Count) };
+
+        var result = new ComparisonResult
+        {
+            Summary = summarySnapshot,
+            Differences = differences.ToImmutable(),
+            RootNode = rootBuilder.ToComparisonNode(),
+            Errors = errors.ToImmutableArray(),
+            Elapsed = stopwatch.Elapsed
+        };
+
+        return result;
+    }
+
+    private static FileMetadata CreateMetadata(SnapshotEntry entry, ImmutableDictionary<string, string?> hashes)
+    {
+        hashes.TryGetValue(entry.RelativePath, out var hash);
+        return new FileMetadata
+        {
+            Size = entry.Size,
+            LastWriteTimeUtc = entry.LastWriteTimeUtc,
+            Hash = hash
+        };
+    }
+
+    private static void PopulateNodeStatistics(NodeBuilder node)
+    {
+        if (node.IsDirectory)
+        {
+            foreach (var child in node.Children)
+            {
+                PopulateNodeStatistics(child);
+                node.EqualCount += child.EqualCount;
+                node.DiffCount += child.DiffCount;
+                node.MissingCount += child.MissingCount;
+                node.ErrorCount += child.ErrorCount;
+            }
+
+            if (node.Status is DifferenceType.MissingLeft or DifferenceType.MissingRight)
+            {
+                node.MissingCount++;
+            }
+            else if (node.Status == DifferenceType.Error)
+            {
+                node.ErrorCount++;
+            }
+        }
+        else
+        {
+            switch (node.Status)
+            {
+                case null:
+                    node.EqualCount++;
+                    break;
+                case DifferenceType.Error:
+                    node.ErrorCount++;
+                    break;
+                case DifferenceType.MissingLeft or DifferenceType.MissingRight:
+                    node.MissingCount++;
+                    break;
+                default:
+                    node.DiffCount++;
+                    break;
+            }
+        }
+    }
+
+    private sealed class NodeBuilder
+    {
+        public NodeBuilder(string name, string relativePath, bool isDirectory, NodeBuilder? parent)
+        {
+            Name = name;
+            RelativePath = relativePath;
+            IsDirectory = isDirectory;
+            Parent = parent;
+        }
+
+        public string Name { get; }
+        public string RelativePath { get; }
+        public bool IsDirectory { get; set; }
+        public NodeBuilder? Parent { get; }
+        public List<NodeBuilder> Children { get; } = new();
+        public SnapshotEntry? LeftEntry { get; set; }
+        public SnapshotEntry? RightEntry { get; set; }
+        public DifferenceType? Status { get; set; }
+        public int EqualCount { get; set; }
+        public int DiffCount { get; set; }
+        public int MissingCount { get; set; }
+        public int ErrorCount { get; set; }
+        public FileMetadata? LeftMetadata { get; set; }
+        public FileMetadata? RightMetadata { get; set; }
+
+        public ComparisonNode ToComparisonNode()
+        {
+            return new ComparisonNode
+            {
+                Name = string.IsNullOrEmpty(Name) ? "root" : Name,
+                RelativePath = RelativePath,
+                IsDirectory = IsDirectory,
+                Status = Status,
+                Children = Children
+                    .OrderBy(c => c.IsDirectory ? 0 : 1)
+                    .ThenBy(c => c.Name, StringComparer.OrdinalIgnoreCase)
+                    .Select(c => c.ToComparisonNode())
+                    .ToImmutableArray(),
+                EqualCount = EqualCount,
+                DiffCount = DiffCount,
+                MissingCount = MissingCount,
+                ErrorCount = ErrorCount,
+                LeftMetadata = LeftMetadata,
+                RightMetadata = RightMetadata
+            };
+        }
+    }
+
+    private sealed class SummaryBuilder
+    {
+        public int TotalFiles;
+        public int TotalDirectories;
+        public int EqualFiles;
+        public int DifferentFiles;
+        public int MissingLeft;
+        public int MissingRight;
+        public int Errors;
+
+        public ComparisonSummary ToSummary() => new()
+        {
+            TotalFiles = TotalFiles,
+            TotalDirectories = TotalDirectories,
+            EqualFiles = EqualFiles,
+            DifferentFiles = DifferentFiles,
+            MissingLeft = MissingLeft,
+            MissingRight = MissingRight,
+            Errors = Errors
+        };
+    }
+}

--- a/src/FsEqual/Core/DifferenceType.cs
+++ b/src/FsEqual/Core/DifferenceType.cs
@@ -1,0 +1,12 @@
+namespace FsEqual.Core;
+
+public enum DifferenceType
+{
+    MissingLeft,
+    MissingRight,
+    TypeMismatch,
+    SizeMismatch,
+    HashMismatch,
+    TimestampMismatch,
+    Error
+}

--- a/src/FsEqual/Core/FailOnCondition.cs
+++ b/src/FsEqual/Core/FailOnCondition.cs
@@ -1,0 +1,8 @@
+namespace FsEqual.Core;
+
+public enum FailOnCondition
+{
+    Any,
+    Diff,
+    Error
+}

--- a/src/FsEqual/Core/FileSystemSnapshot.cs
+++ b/src/FsEqual/Core/FileSystemSnapshot.cs
@@ -1,0 +1,100 @@
+using System.Collections.Immutable;
+using Microsoft.Extensions.FileSystemGlobbing;
+
+namespace FsEqual.Core;
+
+public sealed class FileSystemSnapshot
+{
+    private readonly Dictionary<string, SnapshotEntry> _entries;
+
+    private FileSystemSnapshot(Dictionary<string, SnapshotEntry> entries, StringComparer comparer)
+    {
+        _entries = entries;
+        Comparer = comparer;
+    }
+
+    public IReadOnlyDictionary<string, SnapshotEntry> Entries => _entries;
+    public IEnumerable<string> Paths => _entries.Keys;
+    public StringComparer Comparer { get; }
+    public bool TryGet(string relativePath, out SnapshotEntry entry) => _entries.TryGetValue(relativePath, out entry!);
+
+    public static FileSystemSnapshot Create(
+        string root,
+        bool caseSensitive,
+        bool followSymlinks,
+        ImmutableArray<string> ignoreGlobs,
+        CancellationToken cancellationToken)
+    {
+        var comparer = caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+        var entries = new Dictionary<string, SnapshotEntry>(comparer);
+
+        Matcher? matcher = null;
+        if (ignoreGlobs.Length > 0)
+        {
+            matcher = new Matcher(caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+            matcher.AddInclude("**/*");
+            foreach (var pattern in ignoreGlobs)
+            {
+                matcher.AddExclude(pattern);
+            }
+        }
+
+        var stack = new Stack<(string Absolute, string Relative)>();
+        stack.Push((root, string.Empty));
+
+        while (stack.Count > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var current = stack.Pop();
+            var info = new DirectoryInfo(current.Absolute);
+            if (!info.Exists)
+            {
+                continue;
+            }
+
+            foreach (var entry in info.EnumerateFileSystemInfos())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!followSymlinks && entry.LinkTarget is not null)
+                {
+                    continue;
+                }
+
+                var relative = Path.Combine(current.Relative, entry.Name);
+                var normalizedRelative = Normalize(relative);
+                if (matcher is not null && !matcher.Match(normalizedRelative).HasMatches)
+                {
+                    continue;
+                }
+
+                if ((entry.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
+                {
+                    var dirEntry = new SnapshotEntry(normalizedRelative, true, 0, entry.LastWriteTimeUtc);
+                    entries[normalizedRelative] = dirEntry;
+                    stack.Push((entry.FullName, relative));
+                }
+                else
+                {
+                    var fileInfo = new FileInfo(entry.FullName);
+                    var fileEntry = new SnapshotEntry(normalizedRelative, false, fileInfo.Length, entry.LastWriteTimeUtc);
+                    entries[normalizedRelative] = fileEntry;
+                }
+            }
+        }
+
+        return new FileSystemSnapshot(entries, comparer);
+    }
+
+    private static string Normalize(string path)
+    {
+        return path.Replace(Path.DirectorySeparatorChar, '/');
+    }
+}
+
+public sealed record SnapshotEntry(string RelativePath, bool IsDirectory, long Size, DateTime LastWriteTimeUtc)
+{
+    public string RelativePath { get; init; } = RelativePath;
+    public bool IsDirectory { get; init; } = IsDirectory;
+    public long Size { get; init; } = Size;
+    public DateTime LastWriteTimeUtc { get; init; } = LastWriteTimeUtc;
+}

--- a/src/FsEqual/Core/HashAlgorithmKind.cs
+++ b/src/FsEqual/Core/HashAlgorithmKind.cs
@@ -1,0 +1,9 @@
+namespace FsEqual.Core;
+
+public enum HashAlgorithmKind
+{
+    Crc32,
+    Md5,
+    Sha256,
+    Xxh64
+}

--- a/src/FsEqual/Core/HashComputer.cs
+++ b/src/FsEqual/Core/HashComputer.cs
@@ -1,0 +1,62 @@
+using System.Buffers;
+using System.Security.Cryptography;
+using System.IO.Hashing;
+
+namespace FsEqual.Core;
+
+public sealed class HashComputer
+{
+    private readonly HashAlgorithmKind _algorithm;
+
+    public HashComputer(HashAlgorithmKind algorithm)
+    {
+        _algorithm = algorithm;
+    }
+
+    public string ComputeHash(string filePath, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return _algorithm switch
+        {
+            HashAlgorithmKind.Md5 => Compute(filePath, () => MD5.Create(), cancellationToken),
+            HashAlgorithmKind.Sha256 => Compute(filePath, () => SHA256.Create(), cancellationToken),
+            HashAlgorithmKind.Crc32 => ComputeChecksum(filePath, () => new Crc32(), cancellationToken),
+            HashAlgorithmKind.Xxh64 => ComputeChecksum(filePath, () => new XxHash64(), cancellationToken),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+
+    private static string Compute(string filePath, Func<HashAlgorithm> factory, CancellationToken cancellationToken)
+    {
+        using var stream = File.OpenRead(filePath);
+        using var algorithm = factory();
+        var hash = algorithm.ComputeHash(stream);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static string ComputeChecksum(string filePath, Func<NonCryptographicHashAlgorithm> factory, CancellationToken cancellationToken)
+    {
+        var algorithm = factory();
+        using var stream = File.OpenRead(filePath);
+        var buffer = ArrayPool<byte>.Shared.Rent(64 * 1024);
+        try
+        {
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                algorithm.Append(new ReadOnlySpan<byte>(buffer, 0, read));
+            }
+            var hash = algorithm.GetCurrentHash();
+            return Convert.ToHexString(hash).ToLowerInvariant();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            if (algorithm is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+}

--- a/src/FsEqual/FsEqual.csproj
+++ b/src/FsEqual/FsEqual.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.0" />
+    <PackageReference Include="Spectre.Console" Version="0.48.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.48.0" />
+    <PackageReference Include="System.IO.Hashing" Version="9.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/FsEqual/Interactive/InteractiveSession.cs
+++ b/src/FsEqual/Interactive/InteractiveSession.cs
@@ -1,0 +1,594 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using System.Linq;
+using FsEqual.Core;
+using FsEqual.Reporting;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace FsEqual.Interactive;
+
+public sealed class InteractiveSession
+{
+    private readonly IAnsiConsole _console;
+    private ComparisonOptions _options;
+    private ComparisonResult _result;
+    private NodeView _root = null!;
+    private readonly HashSet<string> _collapsed;
+    private int _selectedIndex;
+    private FilterMode _filterMode = FilterMode.All;
+    private readonly Dictionary<string, DifferenceRecord> _differenceLookup;
+
+    public InteractiveSession(ComparisonOptions options, ComparisonResult result, IAnsiConsole console)
+    {
+        _options = options;
+        _result = result;
+        _console = console;
+        _collapsed = new HashSet<string>(_options.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+        _differenceLookup = result.Differences.GroupBy(d => d.Path, _options.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), _options.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+        BuildTree();
+    }
+
+    public void Run()
+    {
+        var cursorSupported = OperatingSystem.IsWindows();
+        var previousCursor = cursorSupported ? Console.CursorVisible : default;
+        if (cursorSupported)
+        {
+            Console.CursorVisible = false;
+        }
+        try
+        {
+            bool exit = false;
+            while (!exit)
+            {
+                Render();
+                var key = Console.ReadKey(true);
+                switch (key.Key)
+                {
+                    case ConsoleKey.Escape:
+                    case ConsoleKey.Q:
+                        exit = true;
+                        break;
+                    case ConsoleKey.UpArrow:
+                        MoveSelection(-1);
+                        break;
+                    case ConsoleKey.DownArrow:
+                        MoveSelection(1);
+                        break;
+                    case ConsoleKey.LeftArrow:
+                        CollapseOrParent();
+                        break;
+                    case ConsoleKey.RightArrow:
+                        ExpandOrChild();
+                        break;
+                    case ConsoleKey.Enter:
+                        ToggleExpand();
+                        break;
+                    case ConsoleKey.F:
+                        CycleFilter();
+                        break;
+                    case ConsoleKey.E:
+                        ExportPrompt();
+                        break;
+                    case ConsoleKey.R:
+                        Refresh();
+                        break;
+                    case ConsoleKey.A:
+                        ChangeAlgorithm();
+                        break;
+                    case ConsoleKey.L:
+                        CycleVerbosity();
+                        break;
+                    case ConsoleKey.Oem2:
+                        ShowHelp();
+                        break;
+                }
+            }
+        }
+        finally
+        {
+            if (cursorSupported)
+            {
+                Console.CursorVisible = previousCursor;
+            }
+            _console.Clear();
+        }
+    }
+
+    private void Render()
+    {
+        var visible = GetVisibleNodes();
+        if (_selectedIndex >= visible.Count)
+        {
+            _selectedIndex = Math.Max(0, visible.Count - 1);
+        }
+
+        _console.Clear();
+
+        var header = new Panel(new Markup($"[bold]{Markup.Escape(_options.LeftRoot)}[/]\nvs\n[bold]{Markup.Escape(_options.RightRoot)}[/]\nMode: {_options.Mode}, Algo: {_options.HashAlgorithm}, Threads: {_options.Threads?.ToString() ?? "auto"}, Duration: {_result.Elapsed:g}"));
+        var treePanel = new Panel(new Markup(RenderTree(visible)))
+        {
+            Header = new PanelHeader("Structure"),
+            Border = BoxBorder.Square,
+            Padding = new Padding(1)
+        };
+
+        var detailsPanel = new Panel(RenderDetails(visible.Count == 0 ? null : visible[_selectedIndex].View))
+        {
+            Header = new PanelHeader("Details"),
+            Border = BoxBorder.Square,
+            Padding = new Padding(1)
+        };
+
+        var columns = new Columns(treePanel, detailsPanel) { Expand = true };
+        _console.Write(columns);
+        _console.WriteLine();
+
+        _console.MarkupLine($"Filter: [yellow]{_filterMode}[/] | Differences: {_result.Summary.DifferentFiles}, Missing: {_result.Summary.MissingLeft + _result.Summary.MissingRight}, Errors: {_result.Summary.Errors}");
+        _console.MarkupLine("[grey]Keys: ↑/↓ navigate, ←/→ expand/collapse, Enter toggle, F filter, A algorithm, R refresh, E export, L cycle verbosity, Q quit, ? help[/]");
+    }
+
+    private string RenderTree(List<VisibleNode> nodes)
+    {
+        if (nodes.Count == 0)
+        {
+            return "[grey](no nodes)[/]";
+        }
+
+        var builder = new StringBuilder();
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            var node = nodes[i];
+            var indent = new string(' ', node.Depth * 2);
+            var toggle = node.View.Node.IsDirectory ? (_collapsed.Contains(node.View.Node.RelativePath) ? "▸" : "▾") : " ";
+            var glyph = GetGlyph(node.View);
+            var label = FormatLabel(node.View);
+            var line = $"{indent}{toggle} {glyph} {label}";
+            if (node.View.Node.IsDirectory)
+            {
+                line += $" [grey][{node.View.Node.EqualCount}/{node.View.Node.DiffCount}/{node.View.Node.MissingCount}/{node.View.Node.ErrorCount}][/]";
+            }
+
+            if (i == _selectedIndex)
+            {
+                line = $"[reverse]{line}[/]";
+            }
+
+            builder.AppendLine(line);
+        }
+
+        return builder.ToString();
+    }
+
+    private IRenderable RenderDetails(NodeView? view)
+    {
+        if (view is null)
+        {
+            return new Markup("[grey]No selection[/]");
+        }
+
+        var rows = new List<IRenderable>
+        {
+            new Markup($"[bold]{Markup.Escape(view.Node.RelativePath.Length == 0 ? "." : view.Node.RelativePath)}[/]"),
+            new Markup($"Status: {DescribeStatus(view)}")
+        };
+
+        if (view.Node.IsDirectory)
+        {
+            var table = new Table().Border(TableBorder.Rounded).AddColumn("Metric").AddColumn("Value");
+            table.AddRow("Equal", view.Node.EqualCount.ToString());
+            table.AddRow("Diff", view.Node.DiffCount.ToString());
+            table.AddRow("Missing", view.Node.MissingCount.ToString());
+            table.AddRow("Errors", view.Node.ErrorCount.ToString());
+            rows.Add(table);
+        }
+        else
+        {
+            var table = new Table().Border(TableBorder.Rounded);
+            table.AddColumn("Side");
+            table.AddColumn("Size");
+            table.AddColumn("Modified");
+            table.AddColumn("Hash");
+
+            var left = view.Node.LeftMetadata;
+            var right = view.Node.RightMetadata;
+            table.AddRow("Left", FormatSize(left?.Size), FormatTimestamp(left?.LastWriteTimeUtc), left?.Hash ?? string.Empty);
+            table.AddRow("Right", FormatSize(right?.Size), FormatTimestamp(right?.LastWriteTimeUtc), right?.Hash ?? string.Empty);
+            rows.Add(table);
+
+            if (_differenceLookup.TryGetValue(view.Node.RelativePath, out var diff) && !string.IsNullOrEmpty(diff.Reason))
+            {
+                rows.Add(new Markup($"Reason: {Markup.Escape(diff.Reason)}"));
+            }
+        }
+
+        return new Rows(rows);
+    }
+
+    private void MoveSelection(int delta)
+    {
+        var nodes = GetVisibleNodes();
+        if (nodes.Count == 0)
+        {
+            _selectedIndex = 0;
+            return;
+        }
+
+        _selectedIndex = Math.Clamp(_selectedIndex + delta, 0, nodes.Count - 1);
+    }
+
+    private void CollapseOrParent()
+    {
+        var nodes = GetVisibleNodes();
+        if (nodes.Count == 0)
+        {
+            return;
+        }
+
+        var current = nodes[_selectedIndex].View;
+        if (current.Node.IsDirectory && !_collapsed.Contains(current.Node.RelativePath))
+        {
+            if (current.Node.RelativePath.Length > 0)
+            {
+                _collapsed.Add(current.Node.RelativePath);
+            }
+        }
+        else if (current.Parent is not null)
+        {
+            var parentIndex = nodes.FindIndex(n => n.View == current.Parent);
+            if (parentIndex >= 0)
+            {
+                _selectedIndex = parentIndex;
+            }
+        }
+    }
+
+    private void ExpandOrChild()
+    {
+        var nodes = GetVisibleNodes();
+        if (nodes.Count == 0)
+        {
+            return;
+        }
+
+        var current = nodes[_selectedIndex].View;
+        if (current.Node.IsDirectory)
+        {
+            if (_collapsed.Remove(current.Node.RelativePath))
+            {
+                return;
+            }
+
+            if (current.Children.Count > 0)
+            {
+                var childIndex = nodes.FindIndex(n => n.View == current.Children[0]);
+                if (childIndex >= 0)
+                {
+                    _selectedIndex = childIndex;
+                }
+            }
+        }
+    }
+
+    private void ToggleExpand()
+    {
+        var nodes = GetVisibleNodes();
+        if (nodes.Count == 0)
+        {
+            return;
+        }
+
+        var current = nodes[_selectedIndex].View;
+        if (!current.Node.IsDirectory || current.Node.RelativePath.Length == 0)
+        {
+            return;
+        }
+
+        if (_collapsed.Contains(current.Node.RelativePath))
+        {
+            _collapsed.Remove(current.Node.RelativePath);
+        }
+        else
+        {
+            _collapsed.Add(current.Node.RelativePath);
+        }
+    }
+
+    private void CycleFilter()
+    {
+        _filterMode = _filterMode switch
+        {
+            FilterMode.All => FilterMode.Differences,
+            FilterMode.Differences => FilterMode.Errors,
+            _ => FilterMode.All
+        };
+        _selectedIndex = 0;
+    }
+
+    private void ExportPrompt()
+    {
+        var format = AnsiConsole.Prompt(new SelectionPrompt<string>()
+            .Title("Export format")
+            .AddChoices("json", "csv", "markdown"));
+        var path = AnsiConsole.Prompt(new TextPrompt<string>("Enter export path:")
+            .PromptStyle("green")
+            .Validate(s => string.IsNullOrWhiteSpace(s) ? ValidationResult.Error("Path cannot be empty") : ValidationResult.Success()));
+
+        var exporter = new ReportExporter();
+        exporter.ExportAsync(_result, path, format, _console).GetAwaiter().GetResult();
+        AnsiConsole.MarkupLine("[green]Export complete.[/]");
+        AnsiConsole.MarkupLine("Press any key to continue...");
+        Console.ReadKey(true);
+    }
+
+    private void Refresh()
+    {
+        var service = new ComparisonService(_options, _console);
+        _result = service.ExecuteAsync(CancellationToken.None).GetAwaiter().GetResult();
+        _differenceLookup.Clear();
+        foreach (var diff in _result.Differences)
+        {
+            _differenceLookup[diff.Path] = diff;
+        }
+        BuildTree();
+    }
+
+    private void ChangeAlgorithm()
+    {
+        var choices = new[] { "crc32", "md5", "sha256", "xxh64" };
+        var current = _options.HashAlgorithm.ToString().ToLowerInvariant();
+        var prompt = new SelectionPrompt<string>()
+            .Title("Select hash algorithm")
+            .AddChoices(choices)
+            .HighlightStyle(new Style(Color.Yellow));
+        var selected = AnsiConsole.Prompt(prompt);
+        var newAlgorithm = selected switch
+        {
+            "crc32" => HashAlgorithmKind.Crc32,
+            "md5" => HashAlgorithmKind.Md5,
+            "sha256" => HashAlgorithmKind.Sha256,
+            "xxh64" => HashAlgorithmKind.Xxh64,
+            _ => _options.HashAlgorithm
+        };
+
+        _options = _options with { Mode = ComparisonMode.Hash, HashAlgorithm = newAlgorithm };
+        Refresh();
+    }
+
+    private void CycleVerbosity()
+    {
+        AnsiConsole.MarkupLine("[grey]Verbosity cycling not implemented yet.[/]");
+        AnsiConsole.MarkupLine("Press any key to continue...");
+        Console.ReadKey(true);
+    }
+
+    private void ShowHelp()
+    {
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("Key");
+        table.AddColumn("Description");
+        table.AddRow("↑/↓", "Move selection");
+        table.AddRow("←/→", "Collapse/expand navigation");
+        table.AddRow("Enter", "Toggle current directory");
+        table.AddRow("F", "Cycle filters (All → Differences → Errors)");
+        table.AddRow("A", "Re-run comparison with a different hash algorithm");
+        table.AddRow("R", "Refresh comparison with current settings");
+        table.AddRow("E", "Export current differences (json/csv/markdown)");
+        table.AddRow("L", "Reserved for verbosity toggle");
+        table.AddRow("Q", "Quit interactive mode");
+        _console.Clear();
+        _console.Write(table);
+        _console.MarkupLine("Press any key to return.");
+        Console.ReadKey(true);
+    }
+
+    private string FormatLabel(NodeView node)
+    {
+        var name = node.Node.RelativePath.Length == 0 ? "." : node.Node.Name;
+        var color = GetColor(node);
+        return $"[{color}]{Markup.Escape(name)}[/]";
+    }
+
+    private string GetGlyph(NodeView node)
+    {
+        if (node.Node.IsDirectory)
+        {
+            if (node.Node.ErrorCount > 0)
+            {
+                return "[red]?[/]";
+            }
+            if (node.Node.MissingCount > 0 || node.Node.DiffCount > 0)
+            {
+                return "[yellow]![/]";
+            }
+            return "[green]✓[/]";
+        }
+
+        return node.Node.Status switch
+        {
+            null => "[green]✓[/]",
+            DifferenceType.MissingLeft => "[yellow]←[/]",
+            DifferenceType.MissingRight => "[yellow]→[/]",
+            DifferenceType.HashMismatch or DifferenceType.SizeMismatch or DifferenceType.TimestampMismatch => "[yellow]![/]",
+            DifferenceType.Error => "[red]?[/]",
+            _ => "[yellow]![/]"
+        };
+    }
+
+    private string GetColor(NodeView node)
+    {
+        if (node.Node.IsDirectory)
+        {
+            if (node.Node.ErrorCount > 0)
+            {
+                return "red";
+            }
+            if (node.Node.MissingCount > 0 || node.Node.DiffCount > 0)
+            {
+                return "yellow";
+            }
+            return "green";
+        }
+
+        return node.Node.Status switch
+        {
+            null => "green",
+            DifferenceType.Error => "red",
+            DifferenceType.MissingLeft or DifferenceType.MissingRight => "yellow",
+            _ => "yellow"
+        };
+    }
+
+    private string DescribeStatus(NodeView node)
+    {
+        if (node.Node.IsDirectory)
+        {
+            if (node.Node.ErrorCount > 0)
+            {
+                return "Contains errors";
+            }
+            if (node.Node.MissingCount > 0 || node.Node.DiffCount > 0)
+            {
+                return "Contains differences";
+            }
+            return "All children equal";
+        }
+
+        return node.Node.Status switch
+        {
+            null => "Equal",
+            DifferenceType.MissingLeft => "Missing on left",
+            DifferenceType.MissingRight => "Missing on right",
+            DifferenceType.SizeMismatch => "Size mismatch",
+            DifferenceType.HashMismatch => "Hash mismatch",
+            DifferenceType.TimestampMismatch => "Timestamp mismatch",
+            DifferenceType.Error => "Error computing",
+            DifferenceType.TypeMismatch => "Type mismatch",
+            _ => node.Node.Status?.ToString() ?? "Unknown"
+        };
+    }
+
+    private static string FormatSize(long? value)
+    {
+        return value is null ? string.Empty : $"{value:N0} bytes";
+    }
+
+    private static string FormatTimestamp(DateTime? value)
+    {
+        return value is null ? string.Empty : value.Value.ToString("u");
+    }
+
+    private List<VisibleNode> GetVisibleNodes()
+    {
+        var list = new List<VisibleNode>();
+        AppendVisible(_root, 0, list);
+        return list;
+    }
+
+    private void AppendVisible(NodeView node, int depth, List<VisibleNode> list)
+    {
+        if (!ShouldInclude(node))
+        {
+            return;
+        }
+
+        list.Add(new VisibleNode(node, depth));
+        if (node.Node.IsDirectory && !_collapsed.Contains(node.Node.RelativePath))
+        {
+            foreach (var child in node.Children)
+            {
+                AppendVisible(child, depth + 1, list);
+            }
+        }
+    }
+
+    private bool ShouldInclude(NodeView node)
+    {
+        if (_filterMode == FilterMode.All)
+        {
+            return true;
+        }
+
+        bool Matches(NodeView v) => _filterMode switch
+        {
+            FilterMode.Differences => v.Node.DiffCount > 0 || v.Node.MissingCount > 0,
+            FilterMode.Errors => v.Node.ErrorCount > 0,
+            _ => true
+        };
+
+        if (Matches(node))
+        {
+            return true;
+        }
+
+        if (node.Node.IsDirectory)
+        {
+            return node.Children.Any(ShouldInclude);
+        }
+
+        return false;
+    }
+
+    private void BuildTree()
+    {
+        string? selectedPath = null;
+        if (_root is not null)
+        {
+            var previous = GetVisibleNodes();
+            if (previous.Count > 0 && _selectedIndex < previous.Count)
+            {
+                selectedPath = previous[_selectedIndex].View.Node.RelativePath;
+            }
+        }
+
+        _root = BuildNode(_result.RootNode, null);
+
+        var visible = GetVisibleNodes();
+        if (!string.IsNullOrEmpty(selectedPath))
+        {
+            var comparer = _options.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+            var index = visible.FindIndex(n => string.Equals(n.View.Node.RelativePath, selectedPath, comparer));
+            _selectedIndex = index >= 0 ? index : 0;
+        }
+        else
+        {
+            _selectedIndex = 0;
+        }
+    }
+
+    private NodeView BuildNode(ComparisonNode node, NodeView? parent)
+    {
+        var view = new NodeView(node, parent);
+        foreach (var child in node.Children)
+        {
+            view.Children.Add(BuildNode(child, view));
+        }
+        return view;
+    }
+
+    private sealed class NodeView
+    {
+        public NodeView(ComparisonNode node, NodeView? parent)
+        {
+            Node = node;
+            Parent = parent;
+        }
+
+        public ComparisonNode Node { get; }
+        public NodeView? Parent { get; }
+        public List<NodeView> Children { get; } = new();
+    }
+
+    private sealed record VisibleNode(NodeView View, int Depth);
+
+    private enum FilterMode
+    {
+        All,
+        Differences,
+        Errors
+    }
+}

--- a/src/FsEqual/Program.cs
+++ b/src/FsEqual/Program.cs
@@ -1,0 +1,45 @@
+using Spectre.Console.Cli;
+using Spectre.Console;
+using FsEqual.Commands;
+
+var app = new CommandApp();
+
+app.Configure(config =>
+{
+    config.SetApplicationName("fsequal");
+    config.PropagateExceptions();
+    config.ValidateExamples();
+
+    config.AddCommand<CompareCommand>("compare")
+          .WithDescription("Compare two directories and report differences.")
+          .WithExample(new[] { "compare", "./A", "./B" })
+          .WithExample(new[] { "compare", "./A", "./B", "--interactive" })
+          .WithExample(new[]
+          {
+              "compare",
+              "./A",
+              "./B",
+              "-t", "8",
+              "-a", "sha256",
+              "-m", "hash",
+              "-i", "**/bin/**",
+              "-i", "**/obj/**"
+          });
+});
+
+try
+{
+    return app.Run(args);
+}
+catch (CommandRuntimeException ex)
+{
+    AnsiConsole.MarkupLine($"[red]{Markup.Escape(ex.Message)}[/]");
+    AnsiConsole.WriteException(ex);
+    return -2;
+}
+catch (Exception ex)
+{
+    AnsiConsole.MarkupLine($"[red]{Markup.Escape(ex.Message)}[/]");
+    AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything);
+    return -2;
+}

--- a/src/FsEqual/Reporting/ConsoleReporter.cs
+++ b/src/FsEqual/Reporting/ConsoleReporter.cs
@@ -1,0 +1,104 @@
+using FsEqual.Core;
+using Spectre.Console;
+using System.Linq;
+
+namespace FsEqual.Reporting;
+
+public sealed class ConsoleReporter
+{
+    private readonly IAnsiConsole _console;
+    private readonly VerbosityLevel _verbosity;
+
+    public ConsoleReporter(IAnsiConsole console, VerbosityLevel verbosity)
+    {
+        _console = console;
+        _verbosity = verbosity;
+    }
+
+    public void Render(ComparisonResult result, ComparisonOptions options)
+    {
+        var rule = new Rule($"[bold cyan]FsEqual Compare[/] [grey]{options.LeftRoot}[/] ⇆ [grey]{options.RightRoot}[/]");
+        rule.Justify(Justify.Left);
+        _console.Write(rule);
+        _console.MarkupLine($"Mode: [yellow]{options.Mode}[/], Algo: [yellow]{options.HashAlgorithm}[/], Threads: [yellow]{options.Threads?.ToString() ?? "auto"}[/], Duration: [yellow]{result.Elapsed:g}[/]");
+        _console.WriteLine();
+
+        var summaryTable = new Table().Border(TableBorder.Rounded).Title("Summary");
+        summaryTable.AddColumn("Metric");
+        summaryTable.AddColumn("Value");
+        summaryTable.AddRow("Total files", result.Summary.TotalFiles.ToString());
+        summaryTable.AddRow("Total directories", result.Summary.TotalDirectories.ToString());
+        summaryTable.AddRow("Equal files", result.Summary.EqualFiles.ToString());
+        summaryTable.AddRow("Different files", result.Summary.DifferentFiles.ToString());
+        summaryTable.AddRow("Missing left", result.Summary.MissingLeft.ToString());
+        summaryTable.AddRow("Missing right", result.Summary.MissingRight.ToString());
+        summaryTable.AddRow("Errors", result.Summary.Errors.ToString());
+        _console.Write(summaryTable);
+
+        if (result.Differences.Length > 0)
+        {
+            _console.WriteLine();
+            var diffTable = new Table().Border(TableBorder.MinimalHeavyHead);
+            diffTable.AddColumn("Type");
+            diffTable.AddColumn("Path");
+            diffTable.AddColumn("Size (L/R)");
+            diffTable.AddColumn("Algo");
+            diffTable.AddColumn("Reason");
+
+            var maxRows = _verbosity switch
+            {
+                VerbosityLevel.Trace => int.MaxValue,
+                VerbosityLevel.Debug => 250,
+                VerbosityLevel.Info => 100,
+                VerbosityLevel.Warn => 50,
+                _ => 25
+            };
+
+            foreach (var diff in result.Differences.Take(maxRows))
+            {
+                diffTable.AddRow(
+                    diff.Type.ToString(),
+                    diff.Path,
+                    FormatSize(diff.LeftSize, diff.RightSize),
+                    diff.Algorithm ?? string.Empty,
+                    diff.Reason ?? string.Empty);
+            }
+
+            _console.Write(diffTable);
+
+            if (result.Differences.Length > maxRows)
+            {
+                _console.MarkupLine($"[grey]{result.Differences.Length - maxRows} more differences omitted. Re-run with --verbosity debug for more.[/]");
+            }
+        }
+        else
+        {
+            _console.MarkupLine("[green]No differences detected.[/]");
+        }
+
+        if (result.Errors.Length > 0)
+        {
+            _console.WriteLine();
+            _console.MarkupLine("[red]Errors:[/]");
+            foreach (var error in result.Errors.Take(20))
+            {
+                _console.MarkupLineInterpolated($"  [red]-[/] {error}");
+            }
+            if (result.Errors.Length > 20)
+            {
+                _console.MarkupLine($"[grey]{result.Errors.Length - 20} additional errors not shown.[/]");
+            }
+        }
+    }
+
+    private static string FormatSize(long? left, long? right)
+    {
+        if (left is null && right is null)
+        {
+            return string.Empty;
+        }
+
+        string Format(long? value) => value is null ? "-" : $"{value.Value:N0}";
+        return $"{Format(left)} / {Format(right)}";
+    }
+}

--- a/src/FsEqual/Reporting/ReportExporter.cs
+++ b/src/FsEqual/Reporting/ReportExporter.cs
@@ -1,0 +1,126 @@
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using FsEqual.Core;
+using Spectre.Console;
+
+namespace FsEqual.Reporting;
+
+public sealed class ReportExporter
+{
+    public async Task ExportAsync(ComparisonResult result, ComparisonOptions options, IAnsiConsole console)
+    {
+        if (!string.IsNullOrWhiteSpace(options.JsonOutputPath))
+        {
+            await ExportJsonAsync(result, options.JsonOutputPath!, console);
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.SummaryOutputPath))
+        {
+            await ExportSummaryAsync(result, options.SummaryOutputPath!, console);
+        }
+    }
+
+    public async Task ExportAsync(ComparisonResult result, string path, string format, IAnsiConsole? console = null)
+    {
+        format = format.ToLowerInvariant();
+        switch (format)
+        {
+            case "json":
+                await ExportJsonAsync(result, path, console);
+                break;
+            case "csv":
+                await ExportCsvAsync(result, path, console);
+                break;
+            case "markdown":
+            case "md":
+                await ExportMarkdownAsync(result, path, console);
+                break;
+            default:
+                throw new InvalidOperationException($"Unknown export format '{format}'.");
+        }
+    }
+
+    private static async Task ExportJsonAsync(ComparisonResult result, string path, IAnsiConsole? console)
+    {
+        var payload = new
+        {
+            generatedAt = DateTimeOffset.UtcNow,
+            summary = result.Summary,
+            differences = result.Differences,
+            errors = result.Errors,
+            elapsed = result.Elapsed
+        };
+
+        var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+
+        await WriteFileAsync(path, json, console, "JSON report");
+    }
+
+    private static async Task ExportSummaryAsync(ComparisonResult result, string path, IAnsiConsole? console)
+    {
+        var json = JsonSerializer.Serialize(result.Summary, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+        await WriteFileAsync(path, json, console, "summary report");
+    }
+
+    private static async Task ExportCsvAsync(ComparisonResult result, string path, IAnsiConsole? console)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Type,Path,LeftSize,RightSize,Algorithm,Reason");
+        foreach (var diff in result.Differences)
+        {
+            builder.AppendLine(string.Join(',', new[]
+            {
+                Escape(diff.Type.ToString()),
+                Escape(diff.Path),
+                Escape(diff.LeftSize?.ToString() ?? string.Empty),
+                Escape(diff.RightSize?.ToString() ?? string.Empty),
+                Escape(diff.Algorithm ?? string.Empty),
+                Escape(diff.Reason ?? string.Empty)
+            }));
+        }
+
+        await WriteFileAsync(path, builder.ToString(), console, "CSV report");
+    }
+
+    private static async Task ExportMarkdownAsync(ComparisonResult result, string path, IAnsiConsole? console)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# FsEqual Differences");
+        builder.AppendLine();
+        builder.AppendLine($"Generated: {DateTimeOffset.UtcNow:O}");
+        builder.AppendLine();
+        builder.AppendLine("| Type | Path | Left Size | Right Size | Algorithm | Reason |");
+        builder.AppendLine("| --- | --- | --- | --- | --- | --- |");
+        foreach (var diff in result.Differences)
+        {
+            builder.AppendLine($"| {EscapeMarkdown(diff.Type.ToString())} | {EscapeMarkdown(diff.Path)} | {EscapeMarkdown(diff.LeftSize?.ToString() ?? string.Empty)} | {EscapeMarkdown(diff.RightSize?.ToString() ?? string.Empty)} | {EscapeMarkdown(diff.Algorithm ?? string.Empty)} | {EscapeMarkdown(diff.Reason ?? string.Empty)} |");
+        }
+
+        await WriteFileAsync(path, builder.ToString(), console, "Markdown report");
+    }
+
+    private static async Task WriteFileAsync(string path, string content, IAnsiConsole? console, string description)
+    {
+        var fullPath = Path.GetFullPath(path);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath) ?? ".");
+        await File.WriteAllTextAsync(fullPath, content);
+        console?.MarkupLine($"[green]{description} written to[/] [cyan]{fullPath}[/]");
+    }
+
+    private static string Escape(string value)
+    {
+        return '"' + value.Replace("\"", "\"\"") + '"';
+    }
+
+    private static string EscapeMarkdown(string value)
+    {
+        return value.Replace("|", "\\|");
+    }
+}


### PR DESCRIPTION
## Summary
- add FsEqual .NET console project with Spectre.Console CLI entry point
- implement parallelised directory comparison service with hashing, quick mode, and structured results
- provide interactive TUI browser plus console/JSON/CSV/Markdown reporting utilities

## Testing
- `dotnet build src/FsEqual/FsEqual.csproj`
- `dotnet run --project src/FsEqual -- compare samples/A samples/B --no-progress --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68dae00db9f8832a9710ff4840ea1ba8