### PR TITLE
Parallelize directory traversal in comparison engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Build artifacts
+bin/
+obj/
+
+# User-specific files
+*.user
+*.userosscache
+*.suo
+*.cache
+*.pdb
+*.log
+
+# Visual Studio Code
+.vscode/
+
+# Dotnet CLI
+*.deps.json
+*.runtimeconfig.json
+
+# NuGet
+*.nupkg
+.nuget/
+
+# Others
+*.DS_Store

--- a/ParallelCompare.sln
+++ b/ParallelCompare.sln
@@ -1,0 +1,54 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParallelCompare.App", "src\ParallelCompare.App\ParallelCompare.App.csproj", "{14527BDC-7947-4E7E-9496-2081FE959247}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParallelCompare.Core", "src\ParallelCompare.Core\ParallelCompare.Core.csproj", "{C8274295-6390-4EFF-B36A-98FAB09B141A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Debug|x64.Build.0 = Debug|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Debug|x86.Build.0 = Debug|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Release|x64.ActiveCfg = Release|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Release|x64.Build.0 = Release|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Release|x86.ActiveCfg = Release|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Release|x86.Build.0 = Release|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Debug|x64.Build.0 = Debug|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Debug|x86.Build.0 = Debug|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|x64.ActiveCfg = Release|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|x64.Build.0 = Release|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|x86.ActiveCfg = Release|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{14527BDC-7947-4E7E-9496-2081FE959247} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{C8274295-6390-4EFF-B36A-98FAB09B141A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+	EndGlobalSection
+EndGlobal

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,0 +1,34 @@
+# ParallelCompare Integration Checklist
+
+This checklist tracks the work required to deliver the consolidated implementation described in `docs/consolidated-implementation.md`.
+
+## Phase 1 – Foundation Merge
+- [x] Import jzl3qc command modules (`compare`, `watch`, `snapshot`, `completion`).
+- [x] Integrate configuration/profile resolver from base spec implementation.
+- [x] Standardize shared option set and exit codes across commands.
+
+## Phase 2 – Tree Model Integration
+- [x] Replace flat comparison records with hierarchical `ComparisonNode` data model.
+- [x] Adapt exporters and summaries to consume the tree structure.
+- [ ] Implement adapters to stream engine updates into tree nodes for live updates.
+
+## Phase 3 – Interactive Experience Upgrade
+- [ ] Embed Spectre.Console TUI from ehgdxp implementation.
+- [ ] Wire keyboard shortcuts (navigation, filters, algo toggle, exports, diff, pause/resume, help).
+- [ ] Ensure interactive mode respects configuration defaults (theme, filter, verbosity).
+
+## Phase 4 – Watch & Snapshot Enhancements
+- [ ] Merge FileSystemWatcher pipeline with new engine and TUI refresh cycle.
+- [ ] Support `--baseline` comparisons without requiring physical right-hand directory.
+- [ ] Surface watch status and baseline metadata in both CLI and TUI outputs.
+
+## Phase 5 – Testing & Polishing
+- [ ] Author unit tests for configuration resolution, exporter selection, and diff-tool invocation.
+- [ ] Create integration tests for compare/watch/snapshot workflows.
+- [ ] Conduct manual cross-platform validation (Windows, macOS, Linux) for TUI and CLI flows.
+
+## Documentation & Release
+- [x] Produce consolidated implementation plan.
+- [ ] Update user documentation and quickstart guides once implementation stabilizes.
+- [ ] Prepare release notes and onboarding materials for the combined feature set.
+

--- a/docs/consolidated-implementation.md
+++ b/docs/consolidated-implementation.md
@@ -1,0 +1,124 @@
+# ParallelCompare Consolidated Implementation Plan
+
+## Purpose
+
+This document merges the strongest ideas from the four proof-of-concept branches evaluated in `docs/Eval-2.md` into a single, coherent implementation strategy for the `fsEqual` tool. The goal is to satisfy the requirements in `docs/spec.md` by unifying:
+
+- The **command surface, watch mode, and snapshot/baseline workflow** of `codex/implement-plan-in-docs/spec.md-jzl3qc`.
+- The **rich Spectre.Console-driven TUI** from `codex/implement-plan-in-docs/spec.md-ehgdxp`.
+- The **configuration/profile system and validation pipeline** from `codex/implement-plan-in-docs/spec.md`.
+- The **export plumbing and supporting utilities** found in `codex/implement-plan-in-docs/spec.md-fs5wxg`.
+
+## Architectural Overview
+
+The consolidated solution is organized into four layers. Each layer borrows the most robust portion of a prior implementation and adapts it to satisfy the full spec.
+
+1. **Interface Layer**
+   - *Commands*: `compare`, `watch`, `snapshot`, and `completion` (from jzl3qc).
+   - *Interactive UI*: Spectre.Console TUI with tree navigation, filtering, exports, and keyboard shortcuts (from ehgdxp).
+   - *Progress & Logging*: Verbosity-aware console logging coupled with live progress widgets.
+
+2. **Configuration Layer**
+   - *Source Hierarchy*: CLI args → profile → config file → defaults (from base spec & fs5wxg).
+   - *Profiles*: Named presets for hash mode, ignores, exporters, diff tools.
+   - *Validation*: Centralized `SettingsValidator` enforcing path existence, option compatibility, and feature gating.
+
+3. **Comparison Engine**
+   - *Pipelines*: Enumerator → Scheduler → Worker Pool → Aggregator (from jzl3qc core).
+   - *Data Model*: Hierarchical `ComparisonNode` tree with metadata for directories and files (from ehgdxp).
+   - *Hashers*: CRC32 (default), MD5, SHA-256, XXH64 via pluggable providers.
+   - *Diff Integration*: Command-level `--diff-tool` plus interactive `D` shortcut invoking external tools.
+
+4. **Outputs & Automation**
+   - *Reports*: JSON, summary JSON, CSV, Markdown exports with shared schema (from fs5wxg + ehgdxp exporters).
+   - *Snapshots*: Persisted manifest of hashes and metadata, reused for baseline comparisons.
+   - *Watch Mode*: FileSystemWatcher driving debounced re-comparisons; integrates with TUI refresh loop.
+   - *Completion*: Spectre command app provides shell completion generation.
+
+## Feature Integration Details
+
+### CLI Commands
+- Reuse the jzl3qc command shell to ensure parity with the spec.
+- Merge option definitions to include configuration inputs (`--config`, `--profile`) and diff tooling switches.
+- Standardize exit codes (0 equal, 1 diff, 2 error) across all modes.
+
+### Configuration & Profiles
+- Adopt the resolver pipeline from the base spec implementation: parse CLI, hydrate from config, apply profile overrides, produce `ResolvedCompareSettings`.
+- Expose configuration-driven defaults for exporters, ignore patterns, watch debounce durations, and TUI preferences (theme, initial filter).
+
+### Comparison Engine & Data Model
+- Embed the hierarchical `ComparisonNode` structure from the TUI POC inside the multi-threaded engine of jzl3qc.
+- Provide adapters to translate engine events into node updates so the TUI can update in real time.
+- Ensure quick mode (mtime/size) and hash mode share the same tree representation.
+
+### Interactive Experience
+- Integrate the full key-bind set from ehgdxp (navigation, filter, algo toggle, re-run, export, verbosity, pause, help, quit).
+- Extend with watch-mode awareness: show live badges when filesystem events trigger re-runs; allow manual pause/resume from the UI.
+- Support partial re-hashing triggered by selecting a node and pressing `A`.
+
+### Watch Mode
+- Combine FileSystemWatcher logic from jzl3qc with the UI refresh pipeline from ehgdxp.
+- Provide CLI-only operation (console summary) and interactive integration (`--interactive --watch`).
+- Debounce events to avoid redundant runs; surface status in TUI footer.
+
+### Snapshot & Baseline Workflow
+- Use jzl3qc manifest serializer for `fsequal snapshot`.
+- Allow `fsequal compare <path> --baseline baseline.json` to bypass filesystem validation for the right-hand side, supporting offline comparisons.
+- Display baseline metadata within the TUI when active.
+
+### Export Pipeline
+- Consolidate exporters into a shared `IReportExporter` interface with implementations for JSON, summary JSON, CSV, and Markdown.
+- Allow multiple exporters per run; support config-driven exporter defaults.
+- Integrate interactive `E` key to invoke the same exporter infrastructure.
+
+### Logging & Diagnostics
+- Maintain verbosity-aware logger with scopes for engine stages.
+- Provide structured error messages for config issues, missing files, unsupported diff tools, or hash provider failures.
+- Capture telemetry for benchmarking hooks (optional). 
+
+### Extensibility Hooks
+- Plugin model for hash providers and exporters, auto-discovered via dependency injection.
+- Theme customization for TUI via configuration.
+- Extension points for remote compare (future roadmap) left as interfaces.
+
+## Implementation Phases
+
+1. **Foundation Merge**
+   - Import jzl3qc command shell and engine.
+   - Overlay configuration resolver from base spec implementation.
+   - Ensure compare/watch/snapshot commands compile with new settings model.
+
+2. **Tree Model Integration**
+   - Replace flat comparison results with `ComparisonNode` tree.
+   - Adjust exporters and CLI summary to consume the hierarchical model.
+
+3. **Interactive Experience Upgrade**
+   - Integrate ehgdxp Spectre UI, binding it to the new engine adapters.
+   - Wire up exporter prompts and diff tool commands.
+
+4. **Watch & Snapshot Enhancements**
+   - Bridge FileSystemWatcher events into interactive session updates.
+   - Validate baseline workflows within new configuration pipeline.
+
+5. **Testing & Polishing**
+   - Unit tests for settings resolution, exporter outputs, and diff launching.
+   - Integration tests for compare/watch/snapshot commands.
+   - Manual verification of TUI workflows on Windows, macOS, Linux.
+
+## Open Questions
+- How to harmonize progress reporting across CLI and TUI without double-rendering?
+- Should exporter plugins run in parallel or sequentially to preserve log readability?
+- What is the default behavior when both watch mode and interactive algorithm toggling queue work concurrently?
+
+## Success Metrics
+- All commands available and stable.
+- TUI supports full navigation and live refresh.
+- Configured defaults produce consistent results across CLI, TUI, watch, and snapshot modes.
+- Export outputs conform to shared schema and pass JSON schema validation.
+- Baseline comparisons and diff tool invocations succeed across platforms.
+
+## Next Steps
+- Execute Phase 1 tasks (see `docs/checklist.md`).
+- Schedule architecture review once tree model integration is complete.
+- Begin drafting user documentation and onboarding materials post-MVP.
+

--- a/src/ParallelCompare.App/Commands/CompareCommand.cs
+++ b/src/ParallelCompare.App/Commands/CompareCommand.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using ParallelCompare.App.Rendering;
+using ParallelCompare.App.Services;
+using ParallelCompare.Core.Options;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class CompareCommand : AsyncCommand<CompareCommandSettings>
+{
+    private readonly ComparisonOrchestrator _orchestrator;
+
+    public CompareCommand(ComparisonOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, CompareCommandSettings settings)
+    {
+        var input = _orchestrator.BuildInput(settings);
+        using var cancellation = new CancellationTokenSource();
+        ConsoleCancelEventHandler? handler = null;
+
+        try
+        {
+            if (input.Timeout is { } timeout)
+            {
+                cancellation.CancelAfter(timeout);
+            }
+
+            handler = (_, e) =>
+            {
+                e.Cancel = true;
+                cancellation.Cancel();
+            };
+            Console.CancelKeyPress += handler;
+
+            (var result, var resolved) = settings.NoProgress
+                ? await _orchestrator.RunAsync(input, cancellation.Token)
+                : await AnsiConsole.Status()
+                    .StartAsync("Comparing directories...", async _ => await _orchestrator.RunAsync(input, cancellation.Token));
+
+            ComparisonConsoleRenderer.RenderSummary(result);
+
+            if (settings.Interactive)
+            {
+                LaunchInteractive(result);
+            }
+            else
+            {
+                ComparisonConsoleRenderer.RenderTree(result);
+            }
+
+            return DetermineExitCode(resolved.FailOn, result);
+        }
+        catch (OperationCanceledException)
+        {
+            AnsiConsole.MarkupLine("[yellow]Comparison cancelled.[/]");
+            return 2;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything | ExceptionFormats.ShowLinks);
+            return 2;
+        }
+        finally
+        {
+            if (handler is not null)
+            {
+                Console.CancelKeyPress -= handler;
+            }
+        }
+    }
+
+    private static int DetermineExitCode(string? failOn, Core.Comparison.ComparisonResult result)
+    {
+        var summary = result.Summary;
+        var hasDifferences = summary.DifferentFiles > 0 || summary.LeftOnlyFiles > 0 || summary.RightOnlyFiles > 0;
+        var hasErrors = summary.ErrorFiles > 0;
+
+        if (hasErrors)
+        {
+            return 2;
+        }
+
+        var policy = string.IsNullOrWhiteSpace(failOn) ? "diff" : failOn.ToLowerInvariant();
+        return policy switch
+        {
+            "error" => 0,
+            "any" => hasDifferences ? 1 : 0,
+            _ => hasDifferences ? 1 : 0
+        };
+    }
+
+    private static void LaunchInteractive(Core.Comparison.ComparisonResult result)
+    {
+        var stack = new Stack<Core.Comparison.ComparisonNode>();
+        var current = result.Root;
+
+        while (true)
+        {
+            var prompt = new SelectionPrompt<InteractiveOption>()
+                .Title($"[bold]{(string.IsNullOrEmpty(current.RelativePath) ? current.Name : current.RelativePath)}[/] — select a node")
+                .PageSize(15)
+                .UseConverter(option => option.Label);
+
+            var options = BuildOptions(current, stack.Count > 0);
+            prompt.AddChoices(options);
+
+            var choice = AnsiConsole.Prompt(prompt);
+            if (choice.IsExit)
+            {
+                return;
+            }
+
+            if (choice.IsBack)
+            {
+                current = stack.Pop();
+                continue;
+            }
+
+            if (choice.Node is null)
+            {
+                continue;
+            }
+
+            if (choice.Node.NodeType == Core.Comparison.ComparisonNodeType.Directory)
+            {
+                stack.Push(current);
+                current = choice.Node;
+            }
+            else
+            {
+                DisplayFileDetail(choice.Node);
+            }
+        }
+    }
+
+    private static IEnumerable<InteractiveOption> BuildOptions(Core.Comparison.ComparisonNode node, bool canGoBack)
+    {
+        if (canGoBack)
+        {
+            yield return InteractiveOption.Back;
+        }
+
+        foreach (var child in node.Children)
+        {
+            yield return new InteractiveOption(FormatLabel(child), child, false, false);
+        }
+
+        yield return InteractiveOption.Exit;
+    }
+
+    private static string FormatLabel(Core.Comparison.ComparisonNode node)
+    {
+        var status = node.Status switch
+        {
+            Core.Comparison.ComparisonStatus.Equal => "[green]Equal[/]",
+            Core.Comparison.ComparisonStatus.Different => "[yellow]Different[/]",
+            Core.Comparison.ComparisonStatus.LeftOnly => "[blue]Left Only[/]",
+            Core.Comparison.ComparisonStatus.RightOnly => "[magenta]Right Only[/]",
+            Core.Comparison.ComparisonStatus.Error => "[red]Error[/]",
+            _ => node.Status.ToString()
+        };
+
+        return node.NodeType == Core.Comparison.ComparisonNodeType.Directory
+            ? $"{node.Name} ({status})"
+            : $"{node.Name} - {status}";
+    }
+
+    private static void DisplayFileDetail(Core.Comparison.ComparisonNode node)
+    {
+        if (node.Detail is null)
+        {
+            return;
+        }
+
+        var table = new Table().Title($"[bold]{node.Name}[/]");
+        table.AddColumn("Property");
+        table.AddColumn("Left");
+        table.AddColumn("Right");
+
+        table.AddRow("Size", node.Detail.LeftSize?.ToString() ?? "-", node.Detail.RightSize?.ToString() ?? "-");
+        table.AddRow("Modified", node.Detail.LeftModified?.ToString("u") ?? "-", node.Detail.RightModified?.ToString("u") ?? "-");
+
+        if (node.Detail.LeftHashes is not null || node.Detail.RightHashes is not null)
+        {
+            var allAlgorithms = new HashSet<HashAlgorithmType>();
+            if (node.Detail.LeftHashes is not null)
+            {
+                allAlgorithms.UnionWith(node.Detail.LeftHashes.Keys);
+            }
+
+            if (node.Detail.RightHashes is not null)
+            {
+                allAlgorithms.UnionWith(node.Detail.RightHashes.Keys);
+            }
+
+            foreach (var algorithm in allAlgorithms.OrderBy(x => x.ToString()))
+            {
+                string? leftHash = null;
+                if (node.Detail.LeftHashes is not null && node.Detail.LeftHashes.TryGetValue(algorithm, out var l))
+                {
+                    leftHash = l;
+                }
+
+                string? rightHash = null;
+                if (node.Detail.RightHashes is not null && node.Detail.RightHashes.TryGetValue(algorithm, out var r))
+                {
+                    rightHash = r;
+                }
+
+                table.AddRow($"{algorithm} Hash", leftHash ?? "-", rightHash ?? "-");
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(node.Detail.ErrorMessage))
+        {
+            table.AddRow("Error", node.Detail.ErrorMessage, node.Detail.ErrorMessage);
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.MarkupLine("[grey]Press enter to return.[/]");
+        Console.ReadLine();
+    }
+
+    private sealed record InteractiveOption(string Label, Core.Comparison.ComparisonNode? Node, bool IsExit, bool IsBack)
+    {
+        public static InteractiveOption Back { get; } = new("⬆ Back", null, false, true);
+        public static InteractiveOption Exit { get; } = new("Exit", null, true, false);
+    }
+}

--- a/src/ParallelCompare.App/Commands/CompareCommandSettings.cs
+++ b/src/ParallelCompare.App/Commands/CompareCommandSettings.cs
@@ -1,0 +1,70 @@
+using System;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public class CompareCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "<left>")]
+    public string Left { get; init; } = string.Empty;
+
+    [CommandArgument(1, "<right>")]
+    public string Right { get; init; } = string.Empty;
+
+    [CommandOption("-t|--threads")]
+    public int? Threads { get; init; }
+
+    [CommandOption("-a|--algo")]
+    public string[] Algorithms { get; init; } = Array.Empty<string>();
+
+    [CommandOption("-m|--mode")]
+    public string? Mode { get; init; }
+
+    [CommandOption("-i|--ignore")]
+    public string[] Ignore { get; init; } = Array.Empty<string>();
+
+    [CommandOption("--case-sensitive")]
+    public bool CaseSensitive { get; init; }
+
+    [CommandOption("--follow-symlinks")]
+    public bool FollowSymlinks { get; init; }
+
+    [CommandOption("--mtime-tolerance")]
+    public double? ModifiedTimeToleranceSeconds { get; init; }
+
+    [CommandOption("--baseline")]
+    public string? Baseline { get; init; }
+
+    [CommandOption("--json")]
+    public string? JsonReport { get; init; }
+
+    [CommandOption("--summary")]
+    public string? SummaryReport { get; init; }
+
+    [CommandOption("--export")]
+    public string? ExportFormat { get; init; }
+
+    [CommandOption("--no-progress")]
+    public bool NoProgress { get; init; }
+
+    [CommandOption("--diff-tool")]
+    public string? DiffTool { get; init; }
+
+    [CommandOption("--profile")]
+    public string? Profile { get; init; }
+
+    [CommandOption("--config")]
+    public string? ConfigurationPath { get; init; }
+
+    [CommandOption("--verbosity")]
+    public string? Verbosity { get; init; }
+
+    [CommandOption("--fail-on")]
+    public string? FailOn { get; init; }
+
+    [CommandOption("--timeout")]
+    public int? TimeoutSeconds { get; init; }
+
+    [CommandOption("--interactive")]
+    public bool Interactive { get; init; }
+}

--- a/src/ParallelCompare.App/Commands/CompletionCommand.cs
+++ b/src/ParallelCompare.App/Commands/CompletionCommand.cs
@@ -1,0 +1,46 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class CompletionCommand : Command<CompletionCommandSettings>
+{
+    public override int Execute(CommandContext context, CompletionCommandSettings settings)
+    {
+        var script = GenerateScript(settings.Shell);
+        AnsiConsole.Write(script);
+        return 0;
+    }
+
+    private static string GenerateScript(string shell)
+    {
+        return shell.ToLowerInvariant() switch
+        {
+            "bash" => BashScript,
+            "zsh" => ZshScript,
+            "pwsh" or "powershell" => PwshScript,
+            _ => BashScript
+        };
+    }
+
+    private const string BashScript = "_fsequal_completions()\n" +
+        "{\n" +
+        "    local cur prev words cword\n" +
+        "    _init_completion -n : || return\n" +
+        "    COMPREPLY=($(compgen -W \"compare watch snapshot completion --help --version\" -- \"$cur\"))\n" +
+        "}\n" +
+        "complete -F _fsequal_completions fsequal\n";
+
+    private const string ZshScript = "#compdef fsequal\n" +
+        "_fsequal_completions() {\n" +
+        "  _arguments '1: :((compare watch snapshot completion --help --version))'\n" +
+        "}\n" +
+        "compdef _fsequal_completions fsequal\n";
+
+    private const string PwshScript = "Register-ArgumentCompleter -CommandName fsequal -ScriptBlock {\n" +
+        "    param($commandName, $parameterName, $wordToComplete)\n" +
+        "    'compare','watch','snapshot','completion','--help','--version' | Where-Object { $_ -like \"$wordToComplete*\" } | ForEach-Object {\n" +
+        "        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)\n" +
+        "    }\n" +
+        "}\n";
+}

--- a/src/ParallelCompare.App/Commands/CompletionCommandSettings.cs
+++ b/src/ParallelCompare.App/Commands/CompletionCommandSettings.cs
@@ -1,0 +1,9 @@
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class CompletionCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "<shell>")]
+    public string Shell { get; init; } = "bash";
+}

--- a/src/ParallelCompare.App/Commands/SnapshotCommand.cs
+++ b/src/ParallelCompare.App/Commands/SnapshotCommand.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading;
+using ParallelCompare.App.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class SnapshotCommand : AsyncCommand<SnapshotCommandSettings>
+{
+    private readonly ComparisonOrchestrator _orchestrator;
+
+    public SnapshotCommand(ComparisonOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, SnapshotCommandSettings settings)
+    {
+        if (string.IsNullOrWhiteSpace(settings.Output))
+        {
+            AnsiConsole.MarkupLine("[red]--output is required.[/]");
+            return 2;
+        }
+
+        var input = _orchestrator.BuildInput(settings) with
+        {
+            JsonReportPath = settings.Output
+        };
+
+        using var cancellation = new CancellationTokenSource();
+        ConsoleCancelEventHandler? handler = null;
+
+        try
+        {
+            if (input.Timeout is { } timeout)
+            {
+                cancellation.CancelAfter(timeout);
+            }
+
+            handler = (_, e) =>
+            {
+                e.Cancel = true;
+                cancellation.Cancel();
+            };
+            Console.CancelKeyPress += handler;
+
+            await _orchestrator.RunAsync(input, cancellation.Token);
+            AnsiConsole.MarkupLine($"[green]Snapshot written to {settings.Output}.[/]");
+            return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            AnsiConsole.MarkupLine("[yellow]Snapshot cancelled.[/]");
+            return 2;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything | ExceptionFormats.ShowLinks);
+            return 2;
+        }
+        finally
+        {
+            if (handler is not null)
+            {
+                Console.CancelKeyPress -= handler;
+            }
+        }
+    }
+}

--- a/src/ParallelCompare.App/Commands/SnapshotCommandSettings.cs
+++ b/src/ParallelCompare.App/Commands/SnapshotCommandSettings.cs
@@ -1,0 +1,11 @@
+using System;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class SnapshotCommandSettings : CompareCommandSettings
+{
+    [CommandOption("--output <PATH>")]
+    public string Output { get; init; } = string.Empty;
+
+}

--- a/src/ParallelCompare.App/Commands/WatchCommand.cs
+++ b/src/ParallelCompare.App/Commands/WatchCommand.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ParallelCompare.App.Rendering;
+using ParallelCompare.App.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
+{
+    private readonly ComparisonOrchestrator _orchestrator;
+
+    public WatchCommand(ComparisonOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, WatchCommandSettings settings)
+    {
+        var input = _orchestrator.BuildInput(settings);
+        using var cancellation = new CancellationTokenSource();
+        ConsoleCancelEventHandler? handler = null;
+
+        try
+        {
+            if (input.Timeout is { } timeout)
+            {
+                cancellation.CancelAfter(timeout);
+            }
+
+            handler = (_, e) =>
+            {
+                e.Cancel = true;
+                cancellation.Cancel();
+            };
+            Console.CancelKeyPress += handler;
+
+            var resolvedRun = await _orchestrator.RunAsync(input, cancellation.Token);
+            Render(resolvedRun.Result, settings);
+
+            using var semaphore = new SemaphoreSlim(1, 1);
+            using var timer = new Timer(async _ => await RunComparisonAsync(), null, Timeout.Infinite, Timeout.Infinite);
+
+            using var leftWatcher = CreateWatcher(resolvedRun.Resolved.LeftPath, ScheduleRun);
+            using var rightWatcher = CreateWatcher(resolvedRun.Resolved.RightPath, ScheduleRun);
+
+            leftWatcher.EnableRaisingEvents = true;
+            rightWatcher.EnableRaisingEvents = true;
+
+            AnsiConsole.MarkupLine("[grey]Watching for changes. Press Ctrl+C to stop.[/]");
+            try
+            {
+                await Task.Delay(Timeout.Infinite, cancellation.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected on cancellation
+            }
+
+            return 0;
+
+            void ScheduleRun()
+            {
+                timer.Change(TimeSpan.FromMilliseconds(settings.DebounceMilliseconds), Timeout.InfiniteTimeSpan);
+            }
+
+            async Task RunComparisonAsync()
+            {
+                if (!await semaphore.WaitAsync(0, cancellation.Token))
+                {
+                    return;
+                }
+
+                try
+                {
+                    var run = await _orchestrator.RunAsync(input, cancellation.Token);
+                    Render(run.Result, settings);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Ignore cancellation during shutdown.
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            AnsiConsole.MarkupLine("[yellow]Watch cancelled.[/]");
+            return 2;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything | ExceptionFormats.ShowLinks);
+            return 2;
+        }
+        finally
+        {
+            if (handler is not null)
+            {
+                Console.CancelKeyPress -= handler;
+            }
+        }
+    }
+
+    private static FileSystemWatcher CreateWatcher(string path, Action onChange)
+    {
+        var watcher = new FileSystemWatcher(path)
+        {
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.LastWrite
+        };
+
+        void Handler(object? sender, FileSystemEventArgs args) => onChange();
+        void RenamedHandler(object? sender, RenamedEventArgs args) => onChange();
+
+        watcher.Changed += Handler;
+        watcher.Created += Handler;
+        watcher.Deleted += Handler;
+        watcher.Renamed += RenamedHandler;
+
+        return watcher;
+    }
+
+    private static void Render(Core.Comparison.ComparisonResult result, WatchCommandSettings settings)
+    {
+        AnsiConsole.Clear();
+        ComparisonConsoleRenderer.RenderSummary(result);
+        if (!settings.Interactive)
+        {
+            ComparisonConsoleRenderer.RenderTree(result, maxDepth: 2);
+        }
+    }
+}

--- a/src/ParallelCompare.App/Commands/WatchCommandSettings.cs
+++ b/src/ParallelCompare.App/Commands/WatchCommandSettings.cs
@@ -1,0 +1,9 @@
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class WatchCommandSettings : CompareCommandSettings
+{
+    [CommandOption("--debounce <MILLISECONDS>")]
+    public int DebounceMilliseconds { get; init; } = 750;
+}

--- a/src/ParallelCompare.App/Infrastructure/TypeRegistrar.cs
+++ b/src/ParallelCompare.App/Infrastructure/TypeRegistrar.cs
@@ -1,0 +1,55 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Infrastructure;
+
+public sealed class TypeRegistrar : ITypeRegistrar
+{
+    private readonly IServiceCollection _services;
+
+    public TypeRegistrar(IServiceCollection services)
+    {
+        _services = services;
+    }
+
+    public ITypeResolver Build()
+    {
+        return new TypeResolver(_services.BuildServiceProvider());
+    }
+
+    public void Register(Type service, Type implementation)
+    {
+        _services.AddSingleton(service, implementation);
+    }
+
+    public void RegisterInstance(Type service, object implementation)
+    {
+        _services.AddSingleton(service, implementation);
+    }
+
+    public void RegisterLazy(Type service, Func<object> factory)
+    {
+        _services.AddSingleton(service, _ => factory());
+    }
+
+    private sealed class TypeResolver : ITypeResolver, IDisposable
+    {
+        private readonly ServiceProvider _provider;
+
+        public TypeResolver(ServiceProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public object? Resolve(Type? type)
+        {
+            return type is null ? null : _provider.GetService(type);
+        }
+
+        public void Dispose()
+        {
+            _provider.Dispose();
+        }
+    }
+}

--- a/src/ParallelCompare.App/ParallelCompare.App.csproj
+++ b/src/ParallelCompare.App/ParallelCompare.App.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\ParallelCompare.Core\ParallelCompare.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageReference Include="Spectre.Console" Version="0.51.1" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.51.1" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/ParallelCompare.App/Program.cs
+++ b/src/ParallelCompare.App/Program.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.DependencyInjection;
+using ParallelCompare.App.Commands;
+using ParallelCompare.App.Infrastructure;
+using ParallelCompare.App.Services;
+using Spectre.Console.Cli;
+
+var services = new ServiceCollection();
+services.AddSingleton<ComparisonOrchestrator>();
+
+var registrar = new TypeRegistrar(services);
+var app = new CommandApp(registrar);
+
+app.Configure(config =>
+{
+    config.SetApplicationName("fsequal");
+    config.ValidateExamples();
+
+    config.AddCommand<CompareCommand>("compare")
+        .WithDescription("Compare two directories and report differences.");
+
+    config.AddCommand<WatchCommand>("watch")
+        .WithDescription("Continuously compare directories and refresh on changes.");
+
+    config.AddCommand<SnapshotCommand>("snapshot")
+        .WithDescription("Create a snapshot report of the current comparison.");
+
+    config.AddCommand<CompletionCommand>("completion")
+        .WithDescription("Generate shell completion scripts.");
+});
+
+return app.Run(args);

--- a/src/ParallelCompare.App/Rendering/ComparisonConsoleRenderer.cs
+++ b/src/ParallelCompare.App/Rendering/ComparisonConsoleRenderer.cs
@@ -1,0 +1,68 @@
+using System;
+using ParallelCompare.Core.Comparison;
+using Spectre.Console;
+
+namespace ParallelCompare.App.Rendering;
+
+public static class ComparisonConsoleRenderer
+{
+    public static void RenderSummary(ComparisonResult result)
+    {
+        var summary = result.Summary;
+        var table = new Table().Title("[bold]Comparison Summary[/]");
+        table.AddColumn("Metric");
+        table.AddColumn("Value");
+
+        table.AddRow("Total Files", summary.TotalFiles.ToString());
+        table.AddRow("Equal", summary.EqualFiles.ToString());
+        table.AddRow("Different", summary.DifferentFiles.ToString());
+        table.AddRow("Left Only", summary.LeftOnlyFiles.ToString());
+        table.AddRow("Right Only", summary.RightOnlyFiles.ToString());
+        table.AddRow("Errors", summary.ErrorFiles.ToString());
+
+        AnsiConsole.Write(table);
+    }
+
+    public static void RenderTree(ComparisonResult result, int maxDepth = 3)
+    {
+        var tree = new Tree(GetNodeLabel(result.Root));
+        BuildTree(tree.AddNode, result.Root, 1, maxDepth);
+        AnsiConsole.Write(tree);
+    }
+
+    private static void BuildTree(Func<string, TreeNode> addNode, ComparisonNode node, int depth, int maxDepth)
+    {
+        if (depth > maxDepth)
+        {
+            if (node.Children.Length > 0)
+            {
+                addNode("[grey]…[/]");
+            }
+
+            return;
+        }
+
+        foreach (var child in node.Children)
+        {
+            var childNode = addNode(GetNodeLabel(child));
+            BuildTree(childNode.AddNode, child, depth + 1, maxDepth);
+        }
+    }
+
+    private static string GetNodeLabel(ComparisonNode node)
+    {
+        var status = node.Status switch
+        {
+            ComparisonStatus.Equal => "[green]Equal[/]",
+            ComparisonStatus.Different => "[yellow]Different[/]",
+            ComparisonStatus.LeftOnly => "[blue]Left Only[/]",
+            ComparisonStatus.RightOnly => "[magenta]Right Only[/]",
+            ComparisonStatus.Error => "[red]Error[/]",
+            _ => node.Status.ToString()
+        };
+
+        return node.NodeType == ComparisonNodeType.Directory
+            ? $"{node.Name} ({status})"
+            : $"{node.Name} - {status}";
+    }
+}

--- a/src/ParallelCompare.App/Services/ComparisonOrchestrator.cs
+++ b/src/ParallelCompare.App/Services/ComparisonOrchestrator.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using ParallelCompare.App.Commands;
+using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.Configuration;
+using ParallelCompare.Core.Options;
+using ParallelCompare.Core.Reporting;
+
+namespace ParallelCompare.App.Services;
+
+public sealed class ComparisonOrchestrator
+{
+    private readonly ConfigurationLoader _configurationLoader = new();
+    private readonly CompareSettingsResolver _resolver = new();
+    private readonly ComparisonEngine _engine = new();
+    private readonly ComparisonResultExporter _exporter = new();
+
+    public CompareSettingsInput BuildInput(CompareCommandSettings settings)
+    {
+        var algorithms = settings.Algorithms ?? Array.Empty<string>();
+        var algorithm = algorithms.FirstOrDefault();
+        var additional = algorithms.Length > 1
+            ? algorithms.Skip(1).ToImmutableArray()
+            : ImmutableArray<string>.Empty;
+
+        return new CompareSettingsInput
+        {
+            LeftPath = settings.Left,
+            RightPath = settings.Right,
+            Mode = settings.Mode,
+            Algorithm = algorithm,
+            AdditionalAlgorithms = additional,
+            IgnorePatterns = settings.Ignore.Length > 0 ? settings.Ignore.ToImmutableArray() : ImmutableArray<string>.Empty,
+            CaseSensitive = settings.CaseSensitive ? true : null,
+            FollowSymlinks = settings.FollowSymlinks ? true : null,
+            ModifiedTimeTolerance = settings.ModifiedTimeToleranceSeconds.HasValue
+                ? TimeSpan.FromSeconds(settings.ModifiedTimeToleranceSeconds.Value)
+                : null,
+            Threads = settings.Threads,
+            BaselinePath = settings.Baseline,
+            JsonReportPath = settings.JsonReport,
+            SummaryReportPath = settings.SummaryReport,
+            ExportFormat = settings.ExportFormat,
+            NoProgress = settings.NoProgress,
+            DiffTool = settings.DiffTool,
+            Profile = settings.Profile,
+            ConfigurationPath = settings.ConfigurationPath,
+            Verbosity = settings.Verbosity,
+            FailOn = settings.FailOn,
+            Timeout = settings.TimeoutSeconds.HasValue ? TimeSpan.FromSeconds(settings.TimeoutSeconds.Value) : null,
+            EnableInteractive = settings.Interactive
+        };
+    }
+
+    public async Task<(ComparisonResult Result, ResolvedCompareSettings Resolved)> RunAsync(
+        CompareSettingsInput input,
+        CancellationToken cancellationToken)
+    {
+        var configuration = await _configurationLoader.LoadAsync(input.ConfigurationPath, cancellationToken);
+        var resolved = _resolver.Resolve(input, configuration);
+
+        var options = new ComparisonOptions
+        {
+            LeftPath = resolved.LeftPath,
+            RightPath = resolved.RightPath,
+            Mode = resolved.Mode,
+            HashAlgorithms = resolved.Algorithms,
+            IgnorePatterns = resolved.IgnorePatterns,
+            CaseSensitive = resolved.CaseSensitive,
+            FollowSymlinks = resolved.FollowSymlinks,
+            ModifiedTimeTolerance = resolved.ModifiedTimeTolerance,
+            MaxDegreeOfParallelism = resolved.Threads,
+            BaselinePath = resolved.BaselinePath,
+            EnableInteractive = input.EnableInteractive,
+            JsonReportPath = resolved.JsonReportPath,
+            SummaryReportPath = resolved.SummaryReportPath,
+            ExportFormat = resolved.ExportFormat,
+            NoProgress = resolved.NoProgress,
+            DiffTool = resolved.DiffTool,
+            CancellationToken = cancellationToken
+        };
+
+        var result = await _engine.CompareAsync(options);
+
+        if (!string.IsNullOrWhiteSpace(resolved.JsonReportPath))
+        {
+            await _exporter.WriteJsonAsync(result, resolved.JsonReportPath!, cancellationToken);
+        }
+
+        if (!string.IsNullOrWhiteSpace(resolved.SummaryReportPath))
+        {
+            await _exporter.WriteSummaryAsync(result, resolved.SummaryReportPath!, cancellationToken);
+        }
+
+        return (result, resolved);
+    }
+}

--- a/src/ParallelCompare.Core/Comparison/ComparisonEngine.cs
+++ b/src/ParallelCompare.Core/Comparison/ComparisonEngine.cs
@@ -1,0 +1,699 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.FileSystemGlobbing;
+using ParallelCompare.Core.Comparison.Hashing;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Comparison;
+
+public sealed class ComparisonEngine
+{
+    private readonly FileHashCalculator _hashCalculator;
+
+    public ComparisonEngine(FileHashCalculator? hashCalculator = null)
+    {
+        _hashCalculator = hashCalculator ?? new FileHashCalculator();
+    }
+
+    public Task<ComparisonResult> CompareAsync(ComparisonOptions options)
+    {
+        return Task.Run(() => CompareInternal(options), options.CancellationToken);
+    }
+
+    private ComparisonResult CompareInternal(ComparisonOptions options)
+    {
+        var cancellationToken = options.CancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var matcher = BuildMatcher(options);
+        var leftDirectory = new DirectoryInfo(options.LeftPath);
+        var rightDirectory = new DirectoryInfo(options.RightPath);
+
+        if (!leftDirectory.Exists)
+        {
+            throw new DirectoryNotFoundException($"Left directory '{options.LeftPath}' was not found.");
+        }
+
+        if (!rightDirectory.Exists)
+        {
+            throw new DirectoryNotFoundException($"Right directory '{options.RightPath}' was not found.");
+        }
+
+        var root = CompareDirectory(
+            relativePath: string.Empty,
+            displayName: leftDirectory.Name,
+            leftDirectory,
+            rightDirectory,
+            matcher,
+            options,
+            cancellationToken);
+
+        var summary = Summarize(root);
+        return new ComparisonResult(root, summary);
+    }
+
+    private ComparisonNode CompareDirectory(
+        string relativePath,
+        string displayName,
+        DirectoryInfo left,
+        DirectoryInfo right,
+        Matcher? matcher,
+        ComparisonOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var comparer = options.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+
+        var leftEntries = EnumerateEntries(left, relativePath, matcher, comparer);
+        var rightEntries = EnumerateEntries(right, relativePath, matcher, comparer);
+
+        var names = new SortedSet<string>(comparer);
+        names.UnionWith(leftEntries.Keys);
+        names.UnionWith(rightEntries.Keys);
+
+        var workItems = names
+            .Select(name =>
+            {
+                var childRelativePath = string.IsNullOrEmpty(relativePath)
+                    ? name
+                    : Path.Combine(relativePath, name);
+
+                leftEntries.TryGetValue(name, out var leftInfo);
+                rightEntries.TryGetValue(name, out var rightInfo);
+
+                return new EntryWorkItem(name, childRelativePath, leftInfo, rightInfo);
+            })
+            .ToArray();
+
+        var parallelOptions = CreateParallelOptions(options, cancellationToken);
+        Parallel.ForEach(workItems, parallelOptions, item =>
+        {
+            item.Node = BuildNode(
+                item,
+                matcher,
+                options,
+                cancellationToken);
+        });
+
+        var orderedChildren = workItems
+            .OrderBy(item => item.Name, comparer)
+            .Select(item => item.Node ?? throw new InvalidOperationException("Comparison node was not produced for entry."))
+            .ToImmutableArray();
+
+        var status = DetermineDirectoryStatus(orderedChildren);
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.Directory,
+            status,
+            null,
+            orderedChildren);
+    }
+
+    private ComparisonNode BuildNode(
+        EntryWorkItem item,
+        Matcher? matcher,
+        ComparisonOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var leftDir = item.Left as DirectoryInfo;
+        var rightDir = item.Right as DirectoryInfo;
+
+        if (leftDir is not null && rightDir is not null)
+        {
+            return CompareDirectory(
+                item.RelativePath,
+                item.Name,
+                leftDir,
+                rightDir,
+                matcher,
+                options,
+                cancellationToken);
+        }
+
+        if (leftDir is not null && item.Right is FileInfo rightFile)
+        {
+            return BuildTypeMismatchNode(
+                item.Name,
+                item.RelativePath,
+                leftDir,
+                rightFile,
+                cancellationToken);
+        }
+
+        if (rightDir is not null && item.Left is FileInfo leftFile)
+        {
+            return BuildTypeMismatchNode(
+                item.Name,
+                item.RelativePath,
+                leftFile,
+                rightDir,
+                cancellationToken);
+        }
+
+        if (leftDir is not null)
+        {
+            return BuildSingleSideDirectory(
+                item.Name,
+                item.RelativePath,
+                leftDir,
+                ComparisonStatus.LeftOnly,
+                matcher,
+                cancellationToken);
+        }
+
+        if (rightDir is not null)
+        {
+            return BuildSingleSideDirectory(
+                item.Name,
+                item.RelativePath,
+                rightDir,
+                ComparisonStatus.RightOnly,
+                matcher,
+                cancellationToken);
+        }
+
+        return CompareFile(
+            item.RelativePath,
+            item.Name,
+            item.Left as FileInfo,
+            item.Right as FileInfo,
+            options,
+            cancellationToken);
+    }
+
+    private static ParallelOptions CreateParallelOptions(ComparisonOptions options, CancellationToken cancellationToken)
+    {
+        var maxDegree = options.MaxDegreeOfParallelism.HasValue && options.MaxDegreeOfParallelism.Value > 0
+            ? options.MaxDegreeOfParallelism.Value
+            : Environment.ProcessorCount;
+
+        return new ParallelOptions
+        {
+            MaxDegreeOfParallelism = Math.Max(1, maxDegree),
+            CancellationToken = cancellationToken
+        };
+    }
+
+    private ComparisonNode CompareFile(
+        string relativePath,
+        string displayName,
+        FileInfo? left,
+        FileInfo? right,
+        ComparisonOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (left is null && right is null)
+        {
+            throw new InvalidOperationException("Unexpected state: both file references are null.");
+        }
+
+        if (left is null)
+        {
+            return new ComparisonNode(
+                displayName,
+                relativePath,
+                ComparisonNodeType.File,
+                ComparisonStatus.RightOnly,
+                new FileComparisonDetail(
+                    null,
+                    right!.Length,
+                    null,
+                    right.LastWriteTimeUtc,
+                    null,
+                    null,
+                    null),
+                ImmutableArray<ComparisonNode>.Empty);
+        }
+
+        if (right is null)
+        {
+            return new ComparisonNode(
+                displayName,
+                relativePath,
+                ComparisonNodeType.File,
+                ComparisonStatus.LeftOnly,
+                new FileComparisonDetail(
+                    left.Length,
+                    null,
+                    left.LastWriteTimeUtc,
+                    null,
+                    null,
+                    null,
+                    null),
+                ImmutableArray<ComparisonNode>.Empty);
+        }
+
+        try
+        {
+            var status = CompareFileContents(left, right, options, cancellationToken, out var detail);
+            return new ComparisonNode(
+                displayName,
+                relativePath,
+                ComparisonNodeType.File,
+                status,
+                detail,
+                ImmutableArray<ComparisonNode>.Empty);
+        }
+        catch (Exception ex)
+        {
+            return new ComparisonNode(
+                displayName,
+                relativePath,
+                ComparisonNodeType.File,
+                ComparisonStatus.Error,
+                new FileComparisonDetail(
+                    left.Length,
+                    right.Length,
+                    left.LastWriteTimeUtc,
+                    right.LastWriteTimeUtc,
+                    null,
+                    null,
+                    ex.Message),
+                ImmutableArray<ComparisonNode>.Empty);
+        }
+    }
+
+    private ComparisonStatus CompareFileContents(
+        FileInfo left,
+        FileInfo right,
+        ComparisonOptions options,
+        CancellationToken cancellationToken,
+        out FileComparisonDetail detail)
+    {
+        IReadOnlyDictionary<HashAlgorithmType, string>? leftHashes = null;
+        IReadOnlyDictionary<HashAlgorithmType, string>? rightHashes = null;
+
+        if (options.Mode == ComparisonMode.Quick)
+        {
+            var equal = left.Length == right.Length
+                && WithinTolerance(left.LastWriteTimeUtc, right.LastWriteTimeUtc, options.ModifiedTimeTolerance);
+
+            if (!equal && options.HashAlgorithms.IsDefaultOrEmpty)
+            {
+                detail = new FileComparisonDetail(
+                    left.Length,
+                    right.Length,
+                    left.LastWriteTimeUtc,
+                    right.LastWriteTimeUtc,
+                    null,
+                    null,
+                    null);
+                return ComparisonStatus.Different;
+            }
+        }
+
+        if (options.HashAlgorithms.IsDefaultOrEmpty)
+        {
+            // Quick mode fallback: read bytes when metadata mismatch.
+            if (!FilesBinaryEqual(left.FullName, right.FullName, cancellationToken))
+            {
+                detail = new FileComparisonDetail(
+                    left.Length,
+                    right.Length,
+                    left.LastWriteTimeUtc,
+                    right.LastWriteTimeUtc,
+                    null,
+                    null,
+                    null);
+                return ComparisonStatus.Different;
+            }
+
+            detail = new FileComparisonDetail(
+                left.Length,
+                right.Length,
+                left.LastWriteTimeUtc,
+                right.LastWriteTimeUtc,
+                null,
+                null,
+                null);
+            return ComparisonStatus.Equal;
+        }
+
+        leftHashes = _hashCalculator.ComputeHashes(left.FullName, options.HashAlgorithms, cancellationToken);
+        rightHashes = _hashCalculator.ComputeHashes(right.FullName, options.HashAlgorithms, cancellationToken);
+
+        var status = HashesEqual(leftHashes, rightHashes)
+            ? ComparisonStatus.Equal
+            : ComparisonStatus.Different;
+
+        detail = new FileComparisonDetail(
+            left.Length,
+            right.Length,
+            left.LastWriteTimeUtc,
+            right.LastWriteTimeUtc,
+            leftHashes,
+            rightHashes,
+            null);
+        return status;
+    }
+
+    private static bool FilesBinaryEqual(string leftPath, string rightPath, CancellationToken cancellationToken)
+    {
+        const int BufferSize = 8192;
+        using var left = File.OpenRead(leftPath);
+        using var right = File.OpenRead(rightPath);
+
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        var leftBuffer = new byte[BufferSize];
+        var rightBuffer = new byte[BufferSize];
+
+        int leftRead;
+        while ((leftRead = left.Read(leftBuffer, 0, BufferSize)) > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var rightRead = right.Read(rightBuffer, 0, BufferSize);
+            if (leftRead != rightRead)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < leftRead; i++)
+            {
+                if (leftBuffer[i] != rightBuffer[i])
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static ComparisonStatus DetermineDirectoryStatus(IEnumerable<ComparisonNode> children)
+    {
+        var hasError = false;
+        var hasDifferent = false;
+        var hasLeftOnly = false;
+        var hasRightOnly = false;
+
+        foreach (var child in children)
+        {
+            switch (child.Status)
+            {
+                case ComparisonStatus.Error:
+                    hasError = true;
+                    break;
+                case ComparisonStatus.Different:
+                    hasDifferent = true;
+                    break;
+                case ComparisonStatus.LeftOnly:
+                    hasLeftOnly = true;
+                    break;
+                case ComparisonStatus.RightOnly:
+                    hasRightOnly = true;
+                    break;
+            }
+        }
+
+        if (hasError)
+        {
+            return ComparisonStatus.Error;
+        }
+
+        if (hasDifferent || (hasLeftOnly && hasRightOnly))
+        {
+            return ComparisonStatus.Different;
+        }
+
+        if (hasLeftOnly)
+        {
+            return ComparisonStatus.LeftOnly;
+        }
+
+        if (hasRightOnly)
+        {
+            return ComparisonStatus.RightOnly;
+        }
+
+        return ComparisonStatus.Equal;
+    }
+
+    private static ComparisonSummary Summarize(ComparisonNode root)
+    {
+        var totals = (total: 0, equal: 0, different: 0, leftOnly: 0, rightOnly: 0, error: 0);
+        Traverse(root);
+        return new ComparisonSummary(totals.total, totals.equal, totals.different, totals.leftOnly, totals.rightOnly, totals.error);
+
+        void Traverse(ComparisonNode node)
+        {
+            if (node.NodeType == ComparisonNodeType.File)
+            {
+                totals.total++;
+                switch (node.Status)
+                {
+                    case ComparisonStatus.Equal:
+                        totals.equal++;
+                        break;
+                    case ComparisonStatus.Different:
+                        totals.different++;
+                        break;
+                    case ComparisonStatus.LeftOnly:
+                        totals.leftOnly++;
+                        break;
+                    case ComparisonStatus.RightOnly:
+                        totals.rightOnly++;
+                        break;
+                    case ComparisonStatus.Error:
+                        totals.error++;
+                        break;
+                }
+            }
+
+            foreach (var child in node.Children)
+            {
+                Traverse(child);
+            }
+        }
+    }
+
+    private static bool WithinTolerance(DateTimeOffset left, DateTimeOffset right, TimeSpan? tolerance)
+    {
+        if (tolerance is null)
+        {
+            return left == right;
+        }
+
+        var delta = (left - right).Duration();
+        return delta <= tolerance.Value;
+    }
+
+    private static bool ShouldIgnore(FileSystemInfo entry, string parentRelativePath, Matcher? matcher)
+    {
+        if (matcher is null)
+        {
+            return false;
+        }
+
+        var relativePath = string.IsNullOrEmpty(parentRelativePath)
+            ? entry.Name
+            : Path.Combine(parentRelativePath, entry.Name);
+
+        return matcher.Match(relativePath).HasMatches;
+    }
+
+    private static Matcher? BuildMatcher(ComparisonOptions options)
+    {
+        if (options.IgnorePatterns.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        var matcher = new Matcher(options.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+        matcher.AddInclude("**/*");
+        foreach (var pattern in options.IgnorePatterns)
+        {
+            matcher.AddExclude(pattern);
+        }
+
+        return matcher;
+    }
+
+    private static Dictionary<string, FileSystemInfo> EnumerateEntries(
+        DirectoryInfo directory,
+        string relativePath,
+        Matcher? matcher,
+        StringComparer comparer)
+    {
+        var result = new Dictionary<string, FileSystemInfo>(comparer);
+        if (!directory.Exists)
+        {
+            return result;
+        }
+
+        foreach (var entry in directory.EnumerateFileSystemInfos())
+        {
+            if (ShouldIgnore(entry, relativePath, matcher))
+            {
+                continue;
+            }
+
+            result[entry.Name] = entry;
+        }
+
+        return result;
+    }
+
+    private ComparisonNode BuildSingleSideDirectory(
+        string displayName,
+        string relativePath,
+        DirectoryInfo directory,
+        ComparisonStatus status,
+        Matcher? matcher,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var children = new List<ComparisonNode>();
+        foreach (var entry in directory.EnumerateFileSystemInfos())
+        {
+            if (ShouldIgnore(entry, relativePath, matcher))
+            {
+                continue;
+            }
+
+            var childRelativePath = string.IsNullOrEmpty(relativePath)
+                ? entry.Name
+                : Path.Combine(relativePath, entry.Name);
+
+            if (entry is DirectoryInfo childDirectory)
+            {
+                children.Add(BuildSingleSideDirectory(
+                    entry.Name,
+                    childRelativePath,
+                    childDirectory,
+                    status,
+                    matcher,
+                    cancellationToken));
+            }
+            else if (entry is FileInfo file)
+            {
+                var detail = status == ComparisonStatus.LeftOnly
+                    ? new FileComparisonDetail(file.Length, null, file.LastWriteTimeUtc, null, null, null, null)
+                    : new FileComparisonDetail(null, file.Length, null, file.LastWriteTimeUtc, null, null, null);
+
+                children.Add(new ComparisonNode(
+                    entry.Name,
+                    childRelativePath,
+                    ComparisonNodeType.File,
+                    status,
+                    detail,
+                    ImmutableArray<ComparisonNode>.Empty));
+            }
+        }
+
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.Directory,
+            status,
+            null,
+            children.ToImmutableArray());
+    }
+
+    private ComparisonNode BuildTypeMismatchNode(
+        string displayName,
+        string relativePath,
+        FileSystemInfo left,
+        FileSystemInfo right,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        long? leftSize = left is FileInfo leftFile ? leftFile.Length : null;
+        long? rightSize = right is FileInfo rightFile ? rightFile.Length : null;
+
+        var leftModified = left switch
+        {
+            FileInfo lf => lf.LastWriteTimeUtc,
+            DirectoryInfo ld => ld.LastWriteTimeUtc,
+            _ => (DateTimeOffset?)null
+        };
+
+        var rightModified = right switch
+        {
+            FileInfo rf => rf.LastWriteTimeUtc,
+            DirectoryInfo rd => rd.LastWriteTimeUtc,
+            _ => (DateTimeOffset?)null
+        };
+
+        var message = left is DirectoryInfo
+            ? "Left side is a directory while right side is a file."
+            : "Left side is a file while right side is a directory.";
+
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.File,
+            ComparisonStatus.Different,
+            new FileComparisonDetail(
+                leftSize,
+                rightSize,
+                leftModified,
+                rightModified,
+                null,
+                null,
+                message),
+            ImmutableArray<ComparisonNode>.Empty);
+    }
+
+    private static bool HashesEqual(
+        IReadOnlyDictionary<HashAlgorithmType, string> left,
+        IReadOnlyDictionary<HashAlgorithmType, string> right)
+    {
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        foreach (var (key, leftValue) in left)
+        {
+            if (!right.TryGetValue(key, out var rightValue))
+            {
+                return false;
+            }
+
+            if (!string.Equals(leftValue, rightValue, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private sealed class EntryWorkItem
+    {
+        public EntryWorkItem(string name, string relativePath, FileSystemInfo? left, FileSystemInfo? right)
+        {
+            Name = name;
+            RelativePath = relativePath;
+            Left = left;
+            Right = right;
+        }
+
+        public string Name { get; }
+
+        public string RelativePath { get; }
+
+        public FileSystemInfo? Left { get; }
+
+        public FileSystemInfo? Right { get; }
+
+        public ComparisonNode? Node { get; set; }
+    }
+}

--- a/src/ParallelCompare.Core/Comparison/ComparisonNode.cs
+++ b/src/ParallelCompare.Core/Comparison/ComparisonNode.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Comparison;
+
+public enum ComparisonNodeType
+{
+    Directory,
+    File
+}
+
+public enum ComparisonStatus
+{
+    Equal,
+    Different,
+    LeftOnly,
+    RightOnly,
+    Error
+}
+
+public sealed record FileComparisonDetail(
+    long? LeftSize,
+    long? RightSize,
+    DateTimeOffset? LeftModified,
+    DateTimeOffset? RightModified,
+    IReadOnlyDictionary<HashAlgorithmType, string>? LeftHashes,
+    IReadOnlyDictionary<HashAlgorithmType, string>? RightHashes,
+    string? ErrorMessage
+);
+
+public sealed record ComparisonNode(
+    string Name,
+    string RelativePath,
+    ComparisonNodeType NodeType,
+    ComparisonStatus Status,
+    FileComparisonDetail? Detail,
+    ImmutableArray<ComparisonNode> Children
+)
+{
+    public bool HasDifferences => Status is ComparisonStatus.Different or ComparisonStatus.LeftOnly or ComparisonStatus.RightOnly or ComparisonStatus.Error;
+}
+
+public sealed record ComparisonSummary(
+    int TotalFiles,
+    int EqualFiles,
+    int DifferentFiles,
+    int LeftOnlyFiles,
+    int RightOnlyFiles,
+    int ErrorFiles
+);
+
+public sealed record ComparisonResult(
+    ComparisonNode Root,
+    ComparisonSummary Summary
+);

--- a/src/ParallelCompare.Core/Comparison/Hashing/FileHashCalculator.cs
+++ b/src/ParallelCompare.Core/Comparison/Hashing/FileHashCalculator.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Hashing;
+using System.Security.Cryptography;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Comparison.Hashing;
+
+public sealed class FileHashCalculator
+{
+    public IReadOnlyDictionary<HashAlgorithmType, string> ComputeHashes(
+        string filePath,
+        IEnumerable<HashAlgorithmType> algorithms,
+        CancellationToken cancellationToken)
+    {
+        var result = new Dictionary<HashAlgorithmType, string>();
+
+        foreach (var algorithm in algorithms)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            result[algorithm] = ComputeHash(filePath, algorithm);
+        }
+
+        return result;
+    }
+
+    private string ComputeHash(string filePath, HashAlgorithmType algorithm)
+    {
+        return algorithm switch
+        {
+            HashAlgorithmType.Crc32 => ComputeUsingIncremental(filePath, () => new Crc32()),
+            HashAlgorithmType.Md5 => ComputeUsingHashAlgorithm(filePath, MD5.Create),
+            HashAlgorithmType.Sha256 => ComputeUsingHashAlgorithm(filePath, SHA256.Create),
+            HashAlgorithmType.XxHash64 => ComputeUsingIncremental(filePath, () => new XxHash64()),
+            _ => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null)
+        };
+    }
+
+    private static string ComputeUsingHashAlgorithm(string filePath, Func<HashAlgorithm> factory)
+    {
+        using var algorithm = factory();
+        using var stream = File.OpenRead(filePath);
+        var hash = algorithm.ComputeHash(stream);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static string ComputeUsingIncremental(string filePath, Func<NonCryptographicHashAlgorithm> factory)
+    {
+        var algorithm = factory();
+        try
+        {
+            using var stream = File.OpenRead(filePath);
+            var buffer = new byte[8192];
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                algorithm.Append(buffer.AsSpan(0, read));
+            }
+
+            Span<byte> destination = stackalloc byte[algorithm.HashLengthInBytes];
+            algorithm.GetCurrentHash(destination);
+            return Convert.ToHexString(destination).ToLowerInvariant();
+        }
+        finally
+        {
+            (algorithm as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/src/ParallelCompare.Core/Configuration/ConfigurationLoader.cs
+++ b/src/ParallelCompare.Core/Configuration/ConfigurationLoader.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+
+namespace ParallelCompare.Core.Configuration;
+
+public sealed class ConfigurationLoader
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public async Task<ParallelCompareConfiguration?> LoadAsync(string? path, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Configuration file not found: {path}", path);
+        }
+
+        await using var stream = File.OpenRead(path);
+        var config = await JsonSerializer.DeserializeAsync<ParallelCompareConfiguration>(stream, Options, cancellationToken)
+            ?? new ParallelCompareConfiguration();
+
+        return config;
+    }
+}

--- a/src/ParallelCompare.Core/Configuration/ParallelCompareConfiguration.cs
+++ b/src/ParallelCompare.Core/Configuration/ParallelCompareConfiguration.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Serialization;
+
+namespace ParallelCompare.Core.Configuration;
+
+public sealed record ParallelCompareConfiguration
+{
+    [JsonPropertyName("defaults")]
+    public CompareProfile Defaults { get; init; } = new();
+
+    [JsonPropertyName("profiles")]
+    public Dictionary<string, CompareProfile> Profiles { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+}
+
+public class CompareProfile
+{
+    [JsonPropertyName("left")]
+    public string? Left { get; init; }
+
+    [JsonPropertyName("right")]
+    public string? Right { get; init; }
+
+    [JsonPropertyName("mode")]
+    public string? Mode { get; init; }
+
+    [JsonPropertyName("algorithms")]
+    public string[]? Algorithms { get; init; }
+
+    [JsonPropertyName("ignore")]
+    public string[]? Ignore { get; init; }
+
+    [JsonPropertyName("caseSensitive")]
+    public bool? CaseSensitive { get; init; }
+
+    [JsonPropertyName("followSymlinks")]
+    public bool? FollowSymlinks { get; init; }
+
+    [JsonPropertyName("mtimeToleranceSeconds")]
+    public double? MTimeToleranceSeconds { get; init; }
+
+    [JsonPropertyName("threads")]
+    public int? Threads { get; init; }
+
+    [JsonPropertyName("baseline")]
+    public string? Baseline { get; init; }
+
+    [JsonPropertyName("json")]
+    public string? JsonReport { get; init; }
+
+    [JsonPropertyName("summary")]
+    public string? SummaryReport { get; init; }
+
+    [JsonPropertyName("export")]
+    public string? ExportFormat { get; init; }
+
+    [JsonPropertyName("noProgress")]
+    public bool? NoProgress { get; init; }
+
+    [JsonPropertyName("diffTool")]
+    public string? DiffTool { get; init; }
+}

--- a/src/ParallelCompare.Core/Options/CompareSettingsInput.cs
+++ b/src/ParallelCompare.Core/Options/CompareSettingsInput.cs
@@ -1,0 +1,29 @@
+using System.Collections.Immutable;
+
+namespace ParallelCompare.Core.Options;
+
+public sealed record CompareSettingsInput
+{
+    public required string LeftPath { get; init; }
+    public required string RightPath { get; init; }
+    public string? Mode { get; init; }
+    public string? Algorithm { get; init; }
+    public ImmutableArray<string> AdditionalAlgorithms { get; init; } = ImmutableArray<string>.Empty;
+    public ImmutableArray<string> IgnorePatterns { get; init; } = ImmutableArray<string>.Empty;
+    public bool? CaseSensitive { get; init; }
+    public bool? FollowSymlinks { get; init; }
+    public TimeSpan? ModifiedTimeTolerance { get; init; }
+    public int? Threads { get; init; }
+    public string? BaselinePath { get; init; }
+    public bool EnableInteractive { get; init; }
+    public string? JsonReportPath { get; init; }
+    public string? SummaryReportPath { get; init; }
+    public string? ExportFormat { get; init; }
+    public bool NoProgress { get; init; }
+    public string? DiffTool { get; init; }
+    public string? Profile { get; init; }
+    public string? ConfigurationPath { get; init; }
+    public string? Verbosity { get; init; }
+    public string? FailOn { get; init; }
+    public TimeSpan? Timeout { get; init; }
+}

--- a/src/ParallelCompare.Core/Options/CompareSettingsResolver.cs
+++ b/src/ParallelCompare.Core/Options/CompareSettingsResolver.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using ParallelCompare.Core.Configuration;
+
+namespace ParallelCompare.Core.Options;
+
+public sealed class CompareSettingsResolver
+{
+    public ResolvedCompareSettings Resolve(
+        CompareSettingsInput input,
+        ParallelCompareConfiguration? configuration)
+    {
+        var defaults = configuration?.Defaults ?? new CompareProfile();
+        CompareProfile? profile = null;
+
+        if (!string.IsNullOrWhiteSpace(input.Profile))
+        {
+            if (configuration is null)
+            {
+                throw new InvalidOperationException("A configuration file must be provided when using --profile.");
+            }
+
+            if (!configuration.Profiles.TryGetValue(input.Profile!, out profile))
+            {
+                throw new InvalidOperationException($"Profile '{input.Profile}' was not found in the configuration file.");
+            }
+        }
+
+        var left = input.LeftPath ?? profile?.Left ?? defaults.Left
+            ?? throw new InvalidOperationException("Left path must be specified either via CLI or configuration.");
+        var right = input.RightPath ?? profile?.Right ?? defaults.Right
+            ?? throw new InvalidOperationException("Right path must be specified either via CLI or configuration.");
+
+        var mode = ParseMode(input.Mode ?? profile?.Mode ?? defaults.Mode);
+        var algorithms = ResolveAlgorithms(input, profile, defaults, mode);
+        var ignore = MergeArrays(defaults.Ignore, profile?.Ignore, input.IgnorePatterns);
+
+        return new ResolvedCompareSettings
+        {
+            LeftPath = Path.GetFullPath(left),
+            RightPath = Path.GetFullPath(right),
+            Mode = mode,
+            Algorithms = algorithms,
+            IgnorePatterns = ignore,
+            CaseSensitive = input.CaseSensitive ?? profile?.CaseSensitive ?? defaults.CaseSensitive ?? false,
+            FollowSymlinks = input.FollowSymlinks ?? profile?.FollowSymlinks ?? defaults.FollowSymlinks ?? false,
+            ModifiedTimeTolerance = input.ModifiedTimeTolerance
+                ?? ToTimeSpan(profile?.MTimeToleranceSeconds)
+                ?? ToTimeSpan(defaults.MTimeToleranceSeconds),
+            Threads = input.Threads ?? profile?.Threads ?? defaults.Threads,
+            BaselinePath = input.BaselinePath ?? profile?.Baseline ?? defaults.Baseline,
+            JsonReportPath = input.JsonReportPath ?? profile?.JsonReport ?? defaults.JsonReport,
+            SummaryReportPath = input.SummaryReportPath ?? profile?.SummaryReport ?? defaults.SummaryReport,
+            ExportFormat = input.ExportFormat ?? profile?.ExportFormat ?? defaults.ExportFormat,
+            NoProgress = input.NoProgress || profile?.NoProgress == true || defaults.NoProgress == true,
+            DiffTool = input.DiffTool ?? profile?.DiffTool ?? defaults.DiffTool,
+            Verbosity = input.Verbosity,
+            FailOn = input.FailOn,
+            Timeout = input.Timeout
+        };
+    }
+
+    private static ComparisonMode ParseMode(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ComparisonMode.Quick;
+        }
+
+        return value.ToLowerInvariant() switch
+        {
+            "quick" => ComparisonMode.Quick,
+            "hash" => ComparisonMode.Hash,
+            _ => throw new InvalidOperationException($"Unsupported comparison mode '{value}'.")
+        };
+    }
+
+    private static ImmutableArray<HashAlgorithmType> ResolveAlgorithms(
+        CompareSettingsInput input,
+        CompareProfile? profile,
+        CompareProfile defaults,
+        ComparisonMode mode)
+    {
+        var builder = ImmutableArray.CreateBuilder<HashAlgorithmType>();
+        var algorithmNames = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(input.Algorithm))
+        {
+            algorithmNames.Add(input.Algorithm!);
+        }
+
+        if (!input.AdditionalAlgorithms.IsDefaultOrEmpty)
+        {
+            algorithmNames.AddRange(input.AdditionalAlgorithms);
+        }
+
+        if (algorithmNames.Count == 0)
+        {
+            if (profile?.Algorithms?.Length > 0)
+            {
+                algorithmNames.AddRange(profile.Algorithms);
+            }
+            else if (defaults.Algorithms?.Length > 0)
+            {
+                algorithmNames.AddRange(defaults.Algorithms);
+            }
+        }
+
+        if (algorithmNames.Count == 0)
+        {
+            // Default algorithm per spec: crc32 in quick mode, sha256 in hash mode.
+            algorithmNames.Add(mode == ComparisonMode.Quick ? "crc32" : "sha256");
+        }
+
+        foreach (var name in algorithmNames)
+        {
+            builder.Add(ParseAlgorithm(name));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static ImmutableArray<string> MergeArrays(
+        string[]? defaults,
+        string[]? profile,
+        ImmutableArray<string> overrides)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (defaults is { Length: > 0 })
+        {
+            foreach (var value in defaults)
+            {
+                set.Add(value);
+            }
+        }
+
+        if (profile is { Length: > 0 })
+        {
+            foreach (var value in profile)
+            {
+                set.Add(value);
+            }
+        }
+
+        if (!overrides.IsDefaultOrEmpty)
+        {
+            foreach (var value in overrides)
+            {
+                set.Add(value);
+            }
+        }
+
+        return set.ToImmutableArray();
+    }
+
+    private static TimeSpan? ToTimeSpan(double? seconds)
+        => seconds is null ? null : TimeSpan.FromSeconds(seconds.Value);
+
+    private static HashAlgorithmType ParseAlgorithm(string value)
+        => value.ToLowerInvariant() switch
+        {
+            "crc32" => HashAlgorithmType.Crc32,
+            "md5" => HashAlgorithmType.Md5,
+            "sha256" => HashAlgorithmType.Sha256,
+            "xxh64" or "xxhash64" or "xxhash" => HashAlgorithmType.XxHash64,
+            _ => throw new InvalidOperationException($"Unsupported hash algorithm '{value}'.")
+        };
+}

--- a/src/ParallelCompare.Core/Options/ComparisonMode.cs
+++ b/src/ParallelCompare.Core/Options/ComparisonMode.cs
@@ -1,0 +1,7 @@
+namespace ParallelCompare.Core.Options;
+
+public enum ComparisonMode
+{
+    Quick,
+    Hash
+}

--- a/src/ParallelCompare.Core/Options/ComparisonOptions.cs
+++ b/src/ParallelCompare.Core/Options/ComparisonOptions.cs
@@ -1,0 +1,24 @@
+using System.Collections.Immutable;
+
+namespace ParallelCompare.Core.Options;
+
+public sealed record ComparisonOptions
+{
+    public required string LeftPath { get; init; }
+    public required string RightPath { get; init; }
+    public ComparisonMode Mode { get; init; } = ComparisonMode.Quick;
+    public ImmutableArray<HashAlgorithmType> HashAlgorithms { get; init; } = ImmutableArray<HashAlgorithmType>.Empty;
+    public ImmutableArray<string> IgnorePatterns { get; init; } = ImmutableArray<string>.Empty;
+    public bool CaseSensitive { get; init; }
+    public bool FollowSymlinks { get; init; }
+    public TimeSpan? ModifiedTimeTolerance { get; init; }
+    public int? MaxDegreeOfParallelism { get; init; }
+    public string? BaselinePath { get; init; }
+    public bool EnableInteractive { get; init; }
+    public string? JsonReportPath { get; init; }
+    public string? SummaryReportPath { get; init; }
+    public string? ExportFormat { get; init; }
+    public bool NoProgress { get; init; }
+    public string? DiffTool { get; init; }
+    public CancellationToken CancellationToken { get; init; } = CancellationToken.None;
+}

--- a/src/ParallelCompare.Core/Options/HashAlgorithmType.cs
+++ b/src/ParallelCompare.Core/Options/HashAlgorithmType.cs
@@ -1,0 +1,9 @@
+namespace ParallelCompare.Core.Options;
+
+public enum HashAlgorithmType
+{
+    Crc32,
+    Md5,
+    Sha256,
+    XxHash64
+}

--- a/src/ParallelCompare.Core/Options/ResolvedCompareSettings.cs
+++ b/src/ParallelCompare.Core/Options/ResolvedCompareSettings.cs
@@ -1,0 +1,25 @@
+using System.Collections.Immutable;
+
+namespace ParallelCompare.Core.Options;
+
+public sealed record ResolvedCompareSettings
+{
+    public required string LeftPath { get; init; }
+    public required string RightPath { get; init; }
+    public ComparisonMode Mode { get; init; }
+    public ImmutableArray<HashAlgorithmType> Algorithms { get; init; } = ImmutableArray<HashAlgorithmType>.Empty;
+    public ImmutableArray<string> IgnorePatterns { get; init; } = ImmutableArray<string>.Empty;
+    public bool CaseSensitive { get; init; }
+    public bool FollowSymlinks { get; init; }
+    public TimeSpan? ModifiedTimeTolerance { get; init; }
+    public int? Threads { get; init; }
+    public string? BaselinePath { get; init; }
+    public string? JsonReportPath { get; init; }
+    public string? SummaryReportPath { get; init; }
+    public string? ExportFormat { get; init; }
+    public bool NoProgress { get; init; }
+    public string? DiffTool { get; init; }
+    public string? Verbosity { get; init; }
+    public string? FailOn { get; init; }
+    public TimeSpan? Timeout { get; init; }
+}

--- a/src/ParallelCompare.Core/ParallelCompare.Core.csproj
+++ b/src/ParallelCompare.Core/ParallelCompare.Core.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.9" />
+    <PackageReference Include="System.IO.Hashing" Version="9.0.9" />
+  </ItemGroup>
+
+</Project>

--- a/src/ParallelCompare.Core/Reporting/ComparisonResultExporter.cs
+++ b/src/ParallelCompare.Core/Reporting/ComparisonResultExporter.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using ParallelCompare.Core.Comparison;
+
+namespace ParallelCompare.Core.Reporting;
+
+public sealed class ComparisonResultExporter
+{
+    private readonly JsonSerializerOptions _options = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    public async Task WriteJsonAsync(ComparisonResult result, string path, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path)) ?? Directory.GetCurrentDirectory());
+        await using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, ToSerializable(result), _options, cancellationToken);
+    }
+
+    public async Task WriteSummaryAsync(ComparisonResult result, string path, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path)) ?? Directory.GetCurrentDirectory());
+        await using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, result.Summary, _options, cancellationToken);
+    }
+
+    private static SerializableComparisonResult ToSerializable(ComparisonResult result)
+    {
+        return new SerializableComparisonResult
+        {
+            Root = ToSerializable(result.Root),
+            Summary = result.Summary
+        };
+    }
+
+    private static SerializableComparisonNode ToSerializable(ComparisonNode node)
+    {
+        return new SerializableComparisonNode
+        {
+            Name = node.Name,
+            RelativePath = node.RelativePath,
+            NodeType = node.NodeType.ToString(),
+            Status = node.Status.ToString(),
+            Detail = node.Detail is null ? null : new SerializableFileDetail
+            {
+                LeftSize = node.Detail.LeftSize,
+                RightSize = node.Detail.RightSize,
+                LeftModified = node.Detail.LeftModified,
+                RightModified = node.Detail.RightModified,
+                LeftHashes = node.Detail.LeftHashes?.ToDictionary(x => x.Key.ToString(), x => x.Value),
+                RightHashes = node.Detail.RightHashes?.ToDictionary(x => x.Key.ToString(), x => x.Value),
+                ErrorMessage = node.Detail.ErrorMessage
+            },
+            Children = node.Children.Select(ToSerializable).ToList()
+        };
+    }
+
+    private sealed record SerializableComparisonResult
+    {
+        public required SerializableComparisonNode Root { get; init; }
+        public required ComparisonSummary Summary { get; init; }
+    }
+
+    private sealed record SerializableComparisonNode
+    {
+        public required string Name { get; init; }
+        public required string RelativePath { get; init; }
+        public required string NodeType { get; init; }
+        public required string Status { get; init; }
+        public SerializableFileDetail? Detail { get; init; }
+        public required List<SerializableComparisonNode> Children { get; init; }
+    }
+
+    private sealed record SerializableFileDetail
+    {
+        public long? LeftSize { get; init; }
+        public long? RightSize { get; init; }
+        public DateTimeOffset? LeftModified { get; init; }
+        public DateTimeOffset? RightModified { get; init; }
+        public Dictionary<string, string>? LeftHashes { get; init; }
+        public Dictionary<string, string>? RightHashes { get; init; }
+        public string? ErrorMessage { get; init; }
+    }
+}


### PR DESCRIPTION
## Summary
- parallelize directory comparisons using configurable degree of parallelism
- add helper utilities to build comparison nodes safely when traversing entries concurrently
- update the integration checklist to reflect completed tree model work

## Testing
- dotnet build
- dotnet run --project src/ParallelCompare.App -- compare . . --no-progress

------
https://chatgpt.com/codex/tasks/task_e_68daef0eb790832a81ddbfeaac2f3708