### PR TITLE
Add baseline manifest support and surface watch metadata

### DIFF
--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -18,9 +18,9 @@ This checklist tracks the work required to deliver the consolidated implementati
 - [x] Ensure interactive mode respects configuration defaults (theme, filter, verbosity).
 
 ## Phase 4 – Watch & Snapshot Enhancements
-- [ ] Merge FileSystemWatcher pipeline with new engine and TUI refresh cycle.
-- [ ] Support `--baseline` comparisons without requiring physical right-hand directory.
-- [ ] Surface watch status and baseline metadata in both CLI and TUI outputs.
+- [x] Merge FileSystemWatcher pipeline with new engine and TUI refresh cycle.
+- [x] Support `--baseline` comparisons without requiring physical right-hand directory.
+- [x] Surface watch status and baseline metadata in both CLI and TUI outputs.
 
 ## Phase 5 – Testing & Polishing
 - [ ] Author unit tests for configuration resolution, exporter selection, and diff-tool invocation.

--- a/src/ParallelCompare.App/Commands/CompareCommandSettings.cs
+++ b/src/ParallelCompare.App/Commands/CompareCommandSettings.cs
@@ -8,8 +8,8 @@ public class CompareCommandSettings : CommandSettings
     [CommandArgument(0, "<left>")]
     public string Left { get; init; } = string.Empty;
 
-    [CommandArgument(1, "<right>")]
-    public string Right { get; init; } = string.Empty;
+    [CommandArgument(1, "[right]")]
+    public string? Right { get; init; }
 
     [CommandOption("-t|--threads")]
     public int? Threads { get; init; }

--- a/src/ParallelCompare.App/Commands/SnapshotCommand.cs
+++ b/src/ParallelCompare.App/Commands/SnapshotCommand.cs
@@ -23,9 +23,10 @@ public sealed class SnapshotCommand : AsyncCommand<SnapshotCommandSettings>
             return 2;
         }
 
-        var input = _orchestrator.BuildInput(settings) with
+        var baseInput = _orchestrator.BuildInput(settings);
+        var input = baseInput with
         {
-            JsonReportPath = settings.Output
+            RightPath = baseInput.LeftPath
         };
 
         using var cancellation = new CancellationTokenSource();
@@ -45,8 +46,8 @@ public sealed class SnapshotCommand : AsyncCommand<SnapshotCommandSettings>
             };
             Console.CancelKeyPress += handler;
 
-            await _orchestrator.RunAsync(input, cancellation.Token);
-            AnsiConsole.MarkupLine($"[green]Snapshot written to {settings.Output}.[/]");
+            var manifest = await _orchestrator.CreateSnapshotAsync(input, settings.Output, cancellation.Token);
+            AnsiConsole.MarkupLine($"[green]Snapshot written to {settings.Output} (captured {manifest.CreatedAt:u}).[/]");
             return 0;
         }
         catch (OperationCanceledException)

--- a/src/ParallelCompare.App/Commands/WatchCommand.cs
+++ b/src/ParallelCompare.App/Commands/WatchCommand.cs
@@ -2,8 +2,10 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using ParallelCompare.App.Interactive;
 using ParallelCompare.App.Rendering;
 using ParallelCompare.App.Services;
+using ParallelCompare.Core.Options;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -12,10 +14,12 @@ namespace ParallelCompare.App.Commands;
 public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
 {
     private readonly ComparisonOrchestrator _orchestrator;
+    private readonly DiffToolLauncher _diffLauncher;
 
     public WatchCommand(ComparisonOrchestrator orchestrator)
     {
         _orchestrator = orchestrator;
+        _diffLauncher = new DiffToolLauncher();
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, WatchCommandSettings settings)
@@ -39,16 +43,28 @@ public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
             Console.CancelKeyPress += handler;
 
             var resolvedRun = await _orchestrator.RunAsync(input, cancellation.Token);
-            Render(resolvedRun.Result, settings);
+
+            if (settings.Interactive)
+            {
+                await RunInteractiveAsync(resolvedRun.Result, input, resolvedRun.Resolved, settings, cancellation.Token);
+                return 0;
+            }
+
+            Render(resolvedRun.Result, resolvedRun.Resolved, settings);
 
             using var semaphore = new SemaphoreSlim(1, 1);
             using var timer = new Timer(async _ => await RunComparisonAsync(), null, Timeout.Infinite, Timeout.Infinite);
 
             using var leftWatcher = CreateWatcher(resolvedRun.Resolved.LeftPath, ScheduleRun);
-            using var rightWatcher = CreateWatcher(resolvedRun.Resolved.RightPath, ScheduleRun);
+            using FileSystemWatcher? rightWatcher = !resolvedRun.Resolved.UsesBaseline && !string.IsNullOrWhiteSpace(resolvedRun.Resolved.RightPath)
+                ? CreateWatcher(resolvedRun.Resolved.RightPath!, ScheduleRun)
+                : null;
 
             leftWatcher.EnableRaisingEvents = true;
-            rightWatcher.EnableRaisingEvents = true;
+            if (rightWatcher is not null)
+            {
+                rightWatcher.EnableRaisingEvents = true;
+            }
 
             AnsiConsole.MarkupLine("[grey]Watching for changes. Press Ctrl+C to stop.[/]");
             try
@@ -77,7 +93,7 @@ public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
                 try
                 {
                     var run = await _orchestrator.RunAsync(input, cancellation.Token);
-                    Render(run.Result, settings);
+                    Render(run.Result, run.Resolved, settings);
                 }
                 catch (OperationCanceledException)
                 {
@@ -108,6 +124,59 @@ public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
         }
     }
 
+    private async Task RunInteractiveAsync(
+        Core.Comparison.ComparisonResult result,
+        CompareSettingsInput input,
+        ResolvedCompareSettings resolved,
+        WatchCommandSettings settings,
+        CancellationToken cancellationToken)
+    {
+        var interactiveInput = input with
+        {
+            InteractiveFilter = resolved.InteractiveFilter,
+            InteractiveTheme = resolved.InteractiveTheme,
+            InteractiveVerbosity = resolved.InteractiveVerbosity
+        };
+
+        var session = new InteractiveCompareSession(_orchestrator, _diffLauncher);
+
+        using var timer = new Timer(async _ => await TriggerRefreshAsync(), null, Timeout.Infinite, Timeout.Infinite);
+
+        using var leftWatcher = CreateWatcher(resolved.LeftPath, ScheduleRun);
+        using FileSystemWatcher? rightWatcher = !resolved.UsesBaseline && !string.IsNullOrWhiteSpace(resolved.RightPath)
+            ? CreateWatcher(resolved.RightPath!, ScheduleRun)
+            : null;
+
+        leftWatcher.EnableRaisingEvents = true;
+        if (rightWatcher is not null)
+        {
+            rightWatcher.EnableRaisingEvents = true;
+        }
+
+        AnsiConsole.MarkupLine("[grey]Watching for changes. Press Ctrl+C to stop.[/]");
+
+        var initialStatus = resolved.UsesBaseline && resolved.BaselineMetadata is { } baseline
+            ? $"Watching {resolved.LeftPath} against baseline {baseline.ManifestPath}."
+            : $"Watching {resolved.LeftPath} and {resolved.RightPath}.";
+
+        await session.RunAsync(result, interactiveInput, resolved, cancellationToken, initialStatus);
+
+        return;
+
+        void ScheduleRun()
+        {
+            timer.Change(TimeSpan.FromMilliseconds(settings.DebounceMilliseconds), Timeout.InfiniteTimeSpan);
+        }
+
+        async Task TriggerRefreshAsync()
+        {
+            var timestamp = DateTimeOffset.Now.ToLocalTime().ToString("T");
+            var refreshed = $"Filesystem change detected at {timestamp}. Comparison refreshed.";
+            var paused = $"Filesystem change detected at {timestamp}, but refresh is paused.";
+            await session.QueueWatchRefreshAsync(refreshed, paused);
+        }
+    }
+
     private static FileSystemWatcher CreateWatcher(string path, Action onChange)
     {
         var watcher = new FileSystemWatcher(path)
@@ -127,10 +196,11 @@ public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
         return watcher;
     }
 
-    private static void Render(Core.Comparison.ComparisonResult result, WatchCommandSettings settings)
+    private static void Render(Core.Comparison.ComparisonResult result, ResolvedCompareSettings resolved, WatchCommandSettings settings)
     {
         AnsiConsole.Clear();
         ComparisonConsoleRenderer.RenderSummary(result);
+        ComparisonConsoleRenderer.RenderWatchStatus(result, resolved);
         if (!settings.Interactive)
         {
             ComparisonConsoleRenderer.RenderTree(result, maxDepth: 2);

--- a/src/ParallelCompare.Core/Baselines/BaselineComparisonEngine.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineComparisonEngine.cs
@@ -1,0 +1,512 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.FileSystemGlobbing;
+using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.Comparison.Hashing;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Baselines;
+
+public sealed class BaselineComparisonEngine
+{
+    private readonly FileHashCalculator _hashCalculator;
+
+    public BaselineComparisonEngine(FileHashCalculator? hashCalculator = null)
+    {
+        _hashCalculator = hashCalculator ?? new FileHashCalculator();
+    }
+
+    public Task<ComparisonResult> CompareAsync(BaselineComparisonOptions options)
+    {
+        return Task.Run(() => CompareInternal(options), options.CancellationToken);
+    }
+
+    private ComparisonResult CompareInternal(BaselineComparisonOptions options)
+    {
+        var cancellationToken = options.CancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var directory = new DirectoryInfo(options.LeftPath);
+        if (!directory.Exists)
+        {
+            throw new DirectoryNotFoundException($"Left directory '{options.LeftPath}' was not found.");
+        }
+
+        var manifest = options.Manifest;
+        var matcher = BuildMatcher(manifest.IgnorePatterns, manifest.CaseSensitive);
+        var root = CompareDirectory(
+            string.Empty,
+            directory.Name,
+            directory,
+            manifest.Root,
+            matcher,
+            options,
+            cancellationToken);
+
+        var summary = ComparisonSummaryCalculator.Calculate(root);
+        var metadata = new BaselineMetadata(
+            options.BaselinePath,
+            manifest.SourcePath,
+            manifest.CreatedAt,
+            manifest.Algorithms);
+
+        return new ComparisonResult(
+            Path.GetFullPath(options.LeftPath),
+            manifest.SourcePath,
+            root,
+            summary,
+            metadata);
+    }
+
+    private ComparisonNode CompareDirectory(
+        string relativePath,
+        string displayName,
+        DirectoryInfo directory,
+        BaselineEntry baseline,
+        Matcher? matcher,
+        BaselineComparisonOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var comparer = options.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+        var leftEntries = EnumerateEntries(directory, relativePath, matcher, comparer);
+        var baselineEntries = baseline.Children.ToDictionary(entry => entry.Name, comparer);
+        var names = new SortedSet<string>(comparer);
+        names.UnionWith(leftEntries.Keys);
+        names.UnionWith(baselineEntries.Keys);
+
+        var children = new List<ComparisonNode>();
+        foreach (var name in names)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            leftEntries.TryGetValue(name, out var leftInfo);
+            baselineEntries.TryGetValue(name, out var baselineEntry);
+            var childRelativePath = string.IsNullOrEmpty(relativePath)
+                ? name
+                : Path.Combine(relativePath, name);
+
+            if (leftInfo is DirectoryInfo leftDirectory)
+            {
+                if (baselineEntry?.IsDirectory == true)
+                {
+                    children.Add(CompareDirectory(
+                        childRelativePath,
+                        name,
+                        leftDirectory,
+                        baselineEntry,
+                        matcher,
+                        options,
+                        cancellationToken));
+                }
+                else if (baselineEntry is null)
+                {
+                    children.Add(BuildLeftOnlyDirectory(leftDirectory, childRelativePath, name, matcher, options, cancellationToken));
+                }
+                else
+                {
+                    children.Add(BuildTypeMismatchNode(name, childRelativePath, leftDirectory, baselineEntry));
+                }
+            }
+            else if (leftInfo is FileInfo leftFile)
+            {
+                if (baselineEntry?.IsFile == true)
+                {
+                    children.Add(CompareFile(leftFile, baselineEntry, childRelativePath, name, options, cancellationToken));
+                }
+                else if (baselineEntry is null)
+                {
+                    children.Add(BuildLeftOnlyFile(leftFile, childRelativePath, name));
+                }
+                else
+                {
+                    children.Add(BuildTypeMismatchNode(name, childRelativePath, leftFile, baselineEntry));
+                }
+            }
+            else if (baselineEntry is not null)
+            {
+                if (baselineEntry.IsDirectory)
+                {
+                    children.Add(BuildBaselineOnlyDirectory(baselineEntry, childRelativePath));
+                }
+                else
+                {
+                    children.Add(BuildBaselineOnlyFile(baselineEntry, childRelativePath));
+                }
+            }
+        }
+
+        var orderedChildren = children
+            .OrderBy(child => child.Name, comparer)
+            .ToImmutableArray();
+
+        var status = DetermineDirectoryStatus(orderedChildren);
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.Directory,
+            status,
+            null,
+            orderedChildren);
+    }
+
+    private ComparisonNode CompareFile(
+        FileInfo left,
+        BaselineEntry baseline,
+        string relativePath,
+        string displayName,
+        BaselineComparisonOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var algorithms = DetermineAlgorithms(options, baseline);
+        IReadOnlyDictionary<HashAlgorithmType, string>? leftHashes = null;
+        IReadOnlyDictionary<HashAlgorithmType, string>? baselineHashes = null;
+
+        if (!algorithms.IsDefaultOrEmpty)
+        {
+            leftHashes = _hashCalculator.ComputeHashes(left.FullName, algorithms, cancellationToken);
+            baselineHashes = algorithms.ToDictionary(
+                algorithm => algorithm,
+                algorithm => baseline.Hashes.TryGetValue(algorithm, out var value)
+                    ? value
+                    : throw new InvalidOperationException($"Baseline manifest is missing hash '{algorithm}' for '{relativePath}'."));
+        }
+
+        ComparisonStatus status;
+        if (leftHashes is not null && baselineHashes is not null)
+        {
+            status = HashesEqual(leftHashes, baselineHashes)
+                ? ComparisonStatus.Equal
+                : ComparisonStatus.Different;
+        }
+        else
+        {
+            var equal = baseline.Size.HasValue
+                && left.Length == baseline.Size.Value
+                && WithinTolerance(left.LastWriteTimeUtc, baseline.Modified, options.ModifiedTimeTolerance);
+            status = equal ? ComparisonStatus.Equal : ComparisonStatus.Different;
+        }
+
+        var detail = new FileComparisonDetail(
+            left.Length,
+            baseline.Size,
+            left.LastWriteTimeUtc,
+            baseline.Modified,
+            leftHashes,
+            baselineHashes,
+            null);
+
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.File,
+            status,
+            detail,
+            ImmutableArray<ComparisonNode>.Empty);
+    }
+
+    private static ComparisonStatus DetermineDirectoryStatus(ImmutableArray<ComparisonNode> children)
+    {
+        if (children.Length == 0)
+        {
+            return ComparisonStatus.Equal;
+        }
+
+        var hasDifferences = children.Any(child => child.Status is ComparisonStatus.Different or ComparisonStatus.LeftOnly or ComparisonStatus.RightOnly or ComparisonStatus.Error);
+        if (!hasDifferences)
+        {
+            return ComparisonStatus.Equal;
+        }
+
+        if (children.All(child => child.Status == ComparisonStatus.LeftOnly))
+        {
+            return ComparisonStatus.LeftOnly;
+        }
+
+        if (children.All(child => child.Status == ComparisonStatus.RightOnly))
+        {
+            return ComparisonStatus.RightOnly;
+        }
+
+        return ComparisonStatus.Different;
+    }
+
+    private ComparisonNode BuildLeftOnlyDirectory(
+        DirectoryInfo directory,
+        string relativePath,
+        string displayName,
+        Matcher? matcher,
+        BaselineComparisonOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var children = new List<ComparisonNode>();
+        foreach (var entry in directory.EnumerateFileSystemInfos())
+        {
+            if (ShouldIgnore(entry, relativePath, matcher))
+            {
+                continue;
+            }
+
+            var childRelative = string.IsNullOrEmpty(relativePath)
+                ? entry.Name
+                : Path.Combine(relativePath, entry.Name);
+
+            if (entry is DirectoryInfo childDirectory)
+            {
+                var child = BuildLeftOnlyDirectory(childDirectory, childRelative, entry.Name, matcher, options, cancellationToken);
+                children.Add(child);
+            }
+            else if (entry is FileInfo file)
+            {
+                children.Add(BuildLeftOnlyFile(file, childRelative, entry.Name));
+            }
+        }
+
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.Directory,
+            ComparisonStatus.LeftOnly,
+            null,
+            children.ToImmutableArray());
+    }
+
+    private ComparisonNode BuildBaselineOnlyDirectory(BaselineEntry entry, string relativePath)
+    {
+        var children = entry.Children.Select(child =>
+        {
+            var childRelative = string.IsNullOrEmpty(relativePath)
+                ? child.Name
+                : Path.Combine(relativePath, child.Name);
+
+            return child.IsDirectory
+                ? BuildBaselineOnlyDirectory(child, childRelative)
+                : BuildBaselineOnlyFile(child, childRelative);
+        }).ToImmutableArray();
+
+        return new ComparisonNode(
+            entry.Name,
+            relativePath,
+            ComparisonNodeType.Directory,
+            ComparisonStatus.RightOnly,
+            null,
+            children);
+    }
+
+    private static ComparisonNode BuildLeftOnlyFile(FileInfo file, string relativePath, string displayName)
+    {
+        var detail = new FileComparisonDetail(
+            file.Length,
+            null,
+            file.LastWriteTimeUtc,
+            null,
+            null,
+            null,
+            null);
+
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.File,
+            ComparisonStatus.LeftOnly,
+            detail,
+            ImmutableArray<ComparisonNode>.Empty);
+    }
+
+    private static ComparisonNode BuildBaselineOnlyFile(BaselineEntry entry, string relativePath)
+    {
+        var detail = new FileComparisonDetail(
+            null,
+            entry.Size,
+            null,
+            entry.Modified,
+            null,
+            entry.Hashes,
+            null);
+
+        return new ComparisonNode(
+            entry.Name,
+            relativePath,
+            ComparisonNodeType.File,
+            ComparisonStatus.RightOnly,
+            detail,
+            ImmutableArray<ComparisonNode>.Empty);
+    }
+
+    private static ComparisonNode BuildTypeMismatchNode(string displayName, string relativePath, FileSystemInfo left, BaselineEntry baseline)
+    {
+        long? leftSize = left switch
+        {
+            FileInfo lf => lf.Length,
+            DirectoryInfo _ => null,
+            _ => null
+        };
+
+        long? rightSize = baseline.Size;
+
+        DateTimeOffset? leftModified = left switch
+        {
+            FileInfo lf => lf.LastWriteTimeUtc,
+            DirectoryInfo ld => ld.LastWriteTimeUtc,
+            _ => null
+        };
+
+        var message = left is DirectoryInfo
+            ? "Left side is a directory while baseline recorded a file."
+            : "Left side is a file while baseline recorded a directory.";
+
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.File,
+            ComparisonStatus.Different,
+            new FileComparisonDetail(
+                leftSize,
+                rightSize,
+                leftModified,
+                baseline.Modified,
+                null,
+                baseline.Hashes.Count == 0 ? null : baseline.Hashes,
+                message),
+            ImmutableArray<ComparisonNode>.Empty);
+    }
+
+    private static ImmutableArray<HashAlgorithmType> DetermineAlgorithms(BaselineComparisonOptions options, BaselineEntry entry)
+    {
+        if (!options.HashAlgorithms.IsDefaultOrEmpty)
+        {
+            EnsureAlgorithmsAvailable(entry, options.HashAlgorithms);
+            return options.HashAlgorithms;
+        }
+
+        if (entry.Hashes.Count > 0)
+        {
+            return entry.Hashes.Keys.ToImmutableArray();
+        }
+
+        if (!options.Manifest.Algorithms.IsDefaultOrEmpty)
+        {
+            EnsureAlgorithmsAvailable(entry, options.Manifest.Algorithms);
+            return options.Manifest.Algorithms;
+        }
+
+        return ImmutableArray<HashAlgorithmType>.Empty;
+    }
+
+    private static void EnsureAlgorithmsAvailable(BaselineEntry entry, ImmutableArray<HashAlgorithmType> algorithms)
+    {
+        foreach (var algorithm in algorithms)
+        {
+            if (!entry.Hashes.ContainsKey(algorithm))
+            {
+                throw new InvalidOperationException($"Baseline manifest does not contain hashes for algorithm '{algorithm}'.");
+            }
+        }
+    }
+
+    private static bool HashesEqual(
+        IReadOnlyDictionary<HashAlgorithmType, string> left,
+        IReadOnlyDictionary<HashAlgorithmType, string> right)
+    {
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        foreach (var (key, leftValue) in left)
+        {
+            if (!right.TryGetValue(key, out var rightValue))
+            {
+                return false;
+            }
+
+            if (!string.Equals(leftValue, rightValue, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool WithinTolerance(DateTimeOffset? left, DateTimeOffset? right, TimeSpan? tolerance)
+    {
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        if (tolerance is null)
+        {
+            return left.Value == right.Value;
+        }
+
+        var delta = (left.Value - right.Value).Duration();
+        return delta <= tolerance.Value;
+    }
+
+    private static Dictionary<string, FileSystemInfo> EnumerateEntries(
+        DirectoryInfo directory,
+        string relativePath,
+        Matcher? matcher,
+        StringComparer comparer)
+    {
+        var result = new Dictionary<string, FileSystemInfo>(comparer);
+        if (!directory.Exists)
+        {
+            return result;
+        }
+
+        foreach (var entry in directory.EnumerateFileSystemInfos())
+        {
+            if (ShouldIgnore(entry, relativePath, matcher))
+            {
+                continue;
+            }
+
+            result[entry.Name] = entry;
+        }
+
+        return result;
+    }
+
+    private static Matcher? BuildMatcher(ImmutableArray<string> patterns, bool caseSensitive)
+    {
+        if (patterns.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        var matcher = new Matcher(caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+        matcher.AddInclude("**/*");
+        foreach (var pattern in patterns)
+        {
+            matcher.AddExclude(pattern);
+        }
+
+        return matcher;
+    }
+
+    private static bool ShouldIgnore(FileSystemInfo entry, string parentRelativePath, Matcher? matcher)
+    {
+        if (matcher is null)
+        {
+            return false;
+        }
+
+        var relativePath = string.IsNullOrEmpty(parentRelativePath)
+            ? entry.Name
+            : Path.Combine(parentRelativePath, entry.Name);
+
+        return matcher.Match(relativePath).HasMatches;
+    }
+}

--- a/src/ParallelCompare.Core/Baselines/BaselineComparisonOptions.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineComparisonOptions.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Baselines;
+
+public sealed record BaselineComparisonOptions
+{
+    public required string LeftPath { get; init; }
+    public required string BaselinePath { get; init; }
+    public required BaselineManifest Manifest { get; init; }
+    public ImmutableArray<HashAlgorithmType> HashAlgorithms { get; init; } = ImmutableArray<HashAlgorithmType>.Empty;
+    public ImmutableArray<string> IgnorePatterns { get; init; } = ImmutableArray<string>.Empty;
+    public bool CaseSensitive { get; init; }
+    public TimeSpan? ModifiedTimeTolerance { get; init; }
+    public ComparisonMode Mode { get; init; }
+    public CancellationToken CancellationToken { get; init; }
+}

--- a/src/ParallelCompare.Core/Baselines/BaselineEntry.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineEntry.cs
@@ -1,0 +1,24 @@
+using System.Collections.Immutable;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Baselines;
+
+public enum BaselineEntryType
+{
+    Directory,
+    File
+}
+
+public sealed record BaselineEntry(
+    string Name,
+    string RelativePath,
+    BaselineEntryType EntryType,
+    long? Size,
+    DateTimeOffset? Modified,
+    ImmutableDictionary<HashAlgorithmType, string> Hashes,
+    ImmutableArray<BaselineEntry> Children
+)
+{
+    public bool IsDirectory => EntryType == BaselineEntryType.Directory;
+    public bool IsFile => EntryType == BaselineEntryType.File;
+}

--- a/src/ParallelCompare.Core/Baselines/BaselineManifest.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineManifest.cs
@@ -1,0 +1,18 @@
+using System.Collections.Immutable;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Baselines;
+
+public sealed record BaselineManifest(
+    string Version,
+    string SourcePath,
+    DateTimeOffset CreatedAt,
+    ImmutableArray<string> IgnorePatterns,
+    bool CaseSensitive,
+    TimeSpan? ModifiedTimeTolerance,
+    ImmutableArray<HashAlgorithmType> Algorithms,
+    BaselineEntry Root
+)
+{
+    public const string CurrentVersion = "1.0";
+}

--- a/src/ParallelCompare.Core/Baselines/BaselineManifestSerializer.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineManifestSerializer.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Baselines;
+
+public sealed class BaselineManifestSerializer
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        Converters =
+        {
+            new JsonStringEnumConverter()
+        }
+    };
+
+    public async Task WriteAsync(BaselineManifest manifest, string path, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path)) ?? Directory.GetCurrentDirectory());
+        await using var stream = File.Create(path);
+        var payload = ToSerializable(manifest);
+        await JsonSerializer.SerializeAsync(stream, payload, SerializerOptions, cancellationToken);
+    }
+
+    public async Task<BaselineManifest> ReadAsync(string path, CancellationToken cancellationToken)
+    {
+        await using var stream = File.OpenRead(path);
+        var payload = await JsonSerializer.DeserializeAsync<SerializableBaselineManifest>(stream, SerializerOptions, cancellationToken)
+            ?? throw new InvalidOperationException("Baseline manifest could not be deserialized.");
+
+        return FromSerializable(payload);
+    }
+
+    private static SerializableBaselineManifest ToSerializable(BaselineManifest manifest)
+    {
+        return new SerializableBaselineManifest
+        {
+            Version = manifest.Version,
+            SourcePath = manifest.SourcePath,
+            CreatedAt = manifest.CreatedAt,
+            IgnorePatterns = manifest.IgnorePatterns.ToArray(),
+            CaseSensitive = manifest.CaseSensitive,
+            ModifiedTimeTolerance = manifest.ModifiedTimeTolerance,
+            Algorithms = manifest.Algorithms.Select(a => a.ToString()).ToArray(),
+            Root = ToSerializable(manifest.Root)
+        };
+    }
+
+    private static BaselineManifest FromSerializable(SerializableBaselineManifest manifest)
+    {
+        if (!string.Equals(manifest.Version, BaselineManifest.CurrentVersion, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Unsupported baseline manifest version '{manifest.Version}'.");
+        }
+
+        return new BaselineManifest(
+            manifest.Version,
+            manifest.SourcePath,
+            manifest.CreatedAt,
+            manifest.IgnorePatterns?.ToImmutableArray() ?? ImmutableArray<string>.Empty,
+            manifest.CaseSensitive,
+            manifest.ModifiedTimeTolerance,
+            manifest.Algorithms is null
+                ? ImmutableArray<HashAlgorithmType>.Empty
+                : manifest.Algorithms.Select(ParseAlgorithm).ToImmutableArray(),
+            FromSerializable(manifest.Root ?? throw new InvalidOperationException("Baseline manifest root is missing."))
+        );
+    }
+
+    private static SerializableBaselineEntry ToSerializable(BaselineEntry entry)
+    {
+        return new SerializableBaselineEntry
+        {
+            Name = entry.Name,
+            RelativePath = entry.RelativePath,
+            EntryType = entry.EntryType,
+            Size = entry.Size,
+            Modified = entry.Modified,
+            Hashes = entry.Hashes.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value, StringComparer.OrdinalIgnoreCase),
+            Children = entry.Children.Select(ToSerializable).ToArray()
+        };
+    }
+
+    private static BaselineEntry FromSerializable(SerializableBaselineEntry entry)
+    {
+        var hashes = entry.Hashes is null
+            ? ImmutableDictionary<HashAlgorithmType, string>.Empty
+            : entry.Hashes
+                .ToDictionary(kvp => ParseAlgorithm(kvp.Key), kvp => kvp.Value, HashAlgorithmComparer.Instance)
+                .ToImmutableDictionary(HashAlgorithmComparer.Instance);
+
+        return new BaselineEntry(
+            entry.Name ?? throw new InvalidOperationException("Baseline entry name is required."),
+            entry.RelativePath ?? string.Empty,
+            entry.EntryType,
+            entry.Size,
+            entry.Modified,
+            hashes,
+            entry.Children?.Select(FromSerializable).ToImmutableArray() ?? ImmutableArray<BaselineEntry>.Empty);
+    }
+
+    private static HashAlgorithmType ParseAlgorithm(string value)
+    {
+        return Enum.TryParse<HashAlgorithmType>(value, true, out var result)
+            ? result
+            : throw new InvalidOperationException($"Unsupported hash algorithm '{value}' in baseline manifest.");
+    }
+
+    private sealed class HashAlgorithmComparer : IEqualityComparer<HashAlgorithmType>
+    {
+        public static readonly HashAlgorithmComparer Instance = new();
+
+        public bool Equals(HashAlgorithmType x, HashAlgorithmType y) => x == y;
+
+        public int GetHashCode(HashAlgorithmType obj) => (int)obj;
+    }
+
+    private sealed record SerializableBaselineManifest
+    {
+        public string Version { get; init; } = BaselineManifest.CurrentVersion;
+        public string SourcePath { get; init; } = string.Empty;
+        public DateTimeOffset CreatedAt { get; init; }
+        public string[]? IgnorePatterns { get; init; }
+        public bool CaseSensitive { get; init; }
+        public TimeSpan? ModifiedTimeTolerance { get; init; }
+        public string[]? Algorithms { get; init; }
+        public SerializableBaselineEntry? Root { get; init; }
+    }
+
+    private sealed record SerializableBaselineEntry
+    {
+        public string? Name { get; init; }
+        public string? RelativePath { get; init; }
+        public BaselineEntryType EntryType { get; init; }
+        public long? Size { get; init; }
+        public DateTimeOffset? Modified { get; init; }
+        public Dictionary<string, string>? Hashes { get; init; }
+        public SerializableBaselineEntry[]? Children { get; init; }
+    }
+}

--- a/src/ParallelCompare.Core/Baselines/BaselineSnapshotGenerator.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineSnapshotGenerator.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.FileSystemGlobbing;
+using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.Comparison.Hashing;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Baselines;
+
+public sealed class BaselineSnapshotGenerator
+{
+    private readonly FileHashCalculator _hashCalculator;
+
+    public BaselineSnapshotGenerator(FileHashCalculator? hashCalculator = null)
+    {
+        _hashCalculator = hashCalculator ?? new FileHashCalculator();
+    }
+
+    public BaselineManifest CreateSnapshot(ResolvedCompareSettings settings, CancellationToken cancellationToken)
+    {
+        var directory = new DirectoryInfo(settings.LeftPath);
+        if (!directory.Exists)
+        {
+            throw new DirectoryNotFoundException($"Left directory '{settings.LeftPath}' was not found.");
+        }
+
+        var matcher = BuildMatcher(settings.IgnorePatterns, settings.CaseSensitive);
+        var root = BuildDirectory(directory, string.Empty, matcher, settings, cancellationToken);
+
+        return new BaselineManifest(
+            BaselineManifest.CurrentVersion,
+            Path.GetFullPath(settings.LeftPath),
+            DateTimeOffset.UtcNow,
+            settings.IgnorePatterns,
+            settings.CaseSensitive,
+            settings.ModifiedTimeTolerance,
+            settings.Algorithms,
+            root);
+    }
+
+    private BaselineEntry BuildDirectory(
+        DirectoryInfo directory,
+        string relativePath,
+        Matcher? matcher,
+        ResolvedCompareSettings settings,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var comparer = settings.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+        var children = new List<BaselineEntry>();
+
+        foreach (var entry in directory.EnumerateFileSystemInfos())
+        {
+            if (ShouldIgnore(entry, relativePath, matcher))
+            {
+                continue;
+            }
+
+            var childRelative = string.IsNullOrEmpty(relativePath)
+                ? entry.Name
+                : Path.Combine(relativePath, entry.Name);
+
+            if (entry is DirectoryInfo childDirectory)
+            {
+                var child = BuildDirectory(childDirectory, childRelative, matcher, settings, cancellationToken);
+                children.Add(child);
+            }
+            else if (entry is FileInfo file)
+            {
+                var child = BuildFileEntry(file, childRelative, settings, cancellationToken);
+                children.Add(child);
+            }
+        }
+
+        var ordered = children
+            .OrderBy(child => child.Name, comparer)
+            .ToImmutableArray();
+
+        return new BaselineEntry(
+            directory.Name,
+            relativePath,
+            BaselineEntryType.Directory,
+            null,
+            directory.LastWriteTimeUtc,
+            ImmutableDictionary<HashAlgorithmType, string>.Empty,
+            ordered);
+    }
+
+    private BaselineEntry BuildFileEntry(
+        FileInfo file,
+        string relativePath,
+        ResolvedCompareSettings settings,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var hashes = settings.Algorithms.IsDefaultOrEmpty
+            ? ImmutableDictionary<HashAlgorithmType, string>.Empty
+            : _hashCalculator
+                .ComputeHashes(file.FullName, settings.Algorithms, cancellationToken)
+                .ToImmutableDictionary(pair => pair.Key, pair => pair.Value, HashAlgorithmComparer.Instance);
+
+        return new BaselineEntry(
+            file.Name,
+            relativePath,
+            BaselineEntryType.File,
+            file.Length,
+            file.LastWriteTimeUtc,
+            hashes,
+            ImmutableArray<BaselineEntry>.Empty);
+    }
+
+    private static Matcher? BuildMatcher(ImmutableArray<string> patterns, bool caseSensitive)
+    {
+        if (patterns.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        var matcher = new Matcher(caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+        matcher.AddInclude("**/*");
+        foreach (var pattern in patterns)
+        {
+            matcher.AddExclude(pattern);
+        }
+
+        return matcher;
+    }
+
+    private static bool ShouldIgnore(FileSystemInfo entry, string parentRelativePath, Matcher? matcher)
+    {
+        if (matcher is null)
+        {
+            return false;
+        }
+
+        var relativePath = string.IsNullOrEmpty(parentRelativePath)
+            ? entry.Name
+            : Path.Combine(parentRelativePath, entry.Name);
+
+        return matcher.Match(relativePath).HasMatches;
+    }
+
+    private sealed class HashAlgorithmComparer : IEqualityComparer<HashAlgorithmType>
+    {
+        public static readonly HashAlgorithmComparer Instance = new();
+
+        public bool Equals(HashAlgorithmType x, HashAlgorithmType y) => x == y;
+
+        public int GetHashCode(HashAlgorithmType obj) => (int)obj;
+    }
+}

--- a/src/ParallelCompare.Core/Comparison/ComparisonEngine.cs
+++ b/src/ParallelCompare.Core/Comparison/ComparisonEngine.cs
@@ -53,7 +53,7 @@ public sealed class ComparisonEngine
             options,
             cancellationToken);
 
-        var summary = Summarize(root);
+        var summary = ComparisonSummaryCalculator.Calculate(root);
         return new ComparisonResult(
             Path.GetFullPath(options.LeftPath),
             Path.GetFullPath(options.RightPath),
@@ -461,44 +461,6 @@ public sealed class ComparisonEngine
         }
 
         return ComparisonStatus.Equal;
-    }
-
-    private static ComparisonSummary Summarize(ComparisonNode root)
-    {
-        var totals = (total: 0, equal: 0, different: 0, leftOnly: 0, rightOnly: 0, error: 0);
-        Traverse(root);
-        return new ComparisonSummary(totals.total, totals.equal, totals.different, totals.leftOnly, totals.rightOnly, totals.error);
-
-        void Traverse(ComparisonNode node)
-        {
-            if (node.NodeType == ComparisonNodeType.File)
-            {
-                totals.total++;
-                switch (node.Status)
-                {
-                    case ComparisonStatus.Equal:
-                        totals.equal++;
-                        break;
-                    case ComparisonStatus.Different:
-                        totals.different++;
-                        break;
-                    case ComparisonStatus.LeftOnly:
-                        totals.leftOnly++;
-                        break;
-                    case ComparisonStatus.RightOnly:
-                        totals.rightOnly++;
-                        break;
-                    case ComparisonStatus.Error:
-                        totals.error++;
-                        break;
-                }
-            }
-
-            foreach (var child in node.Children)
-            {
-                Traverse(child);
-            }
-        }
     }
 
     private static bool WithinTolerance(DateTimeOffset left, DateTimeOffset right, TimeSpan? tolerance)

--- a/src/ParallelCompare.Core/Comparison/ComparisonNode.cs
+++ b/src/ParallelCompare.Core/Comparison/ComparisonNode.cs
@@ -53,5 +53,13 @@ public sealed record ComparisonResult(
     string LeftPath,
     string RightPath,
     ComparisonNode Root,
-    ComparisonSummary Summary
+    ComparisonSummary Summary,
+    BaselineMetadata? Baseline = null
+);
+
+public sealed record BaselineMetadata(
+    string ManifestPath,
+    string SourcePath,
+    DateTimeOffset CreatedAt,
+    ImmutableArray<HashAlgorithmType> Algorithms
 );

--- a/src/ParallelCompare.Core/Comparison/ComparisonSummaryCalculator.cs
+++ b/src/ParallelCompare.Core/Comparison/ComparisonSummaryCalculator.cs
@@ -1,0 +1,44 @@
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Comparison;
+
+public static class ComparisonSummaryCalculator
+{
+    public static ComparisonSummary Calculate(ComparisonNode root)
+    {
+        var totals = (total: 0, equal: 0, different: 0, leftOnly: 0, rightOnly: 0, error: 0);
+        Traverse(root);
+        return new ComparisonSummary(totals.total, totals.equal, totals.different, totals.leftOnly, totals.rightOnly, totals.error);
+
+        void Traverse(ComparisonNode node)
+        {
+            if (node.NodeType == ComparisonNodeType.File)
+            {
+                totals.total++;
+                switch (node.Status)
+                {
+                    case ComparisonStatus.Equal:
+                        totals.equal++;
+                        break;
+                    case ComparisonStatus.Different:
+                        totals.different++;
+                        break;
+                    case ComparisonStatus.LeftOnly:
+                        totals.leftOnly++;
+                        break;
+                    case ComparisonStatus.RightOnly:
+                        totals.rightOnly++;
+                        break;
+                    case ComparisonStatus.Error:
+                        totals.error++;
+                        break;
+                }
+            }
+
+            foreach (var child in node.Children)
+            {
+                Traverse(child);
+            }
+        }
+    }
+}

--- a/src/ParallelCompare.Core/Options/CompareSettingsInput.cs
+++ b/src/ParallelCompare.Core/Options/CompareSettingsInput.cs
@@ -5,7 +5,7 @@ namespace ParallelCompare.Core.Options;
 public sealed record CompareSettingsInput
 {
     public required string LeftPath { get; init; }
-    public required string RightPath { get; init; }
+    public string? RightPath { get; init; }
     public string? Mode { get; init; }
     public string? Algorithm { get; init; }
     public ImmutableArray<string> AdditionalAlgorithms { get; init; } = ImmutableArray<string>.Empty;

--- a/src/ParallelCompare.Core/Options/ResolvedCompareSettings.cs
+++ b/src/ParallelCompare.Core/Options/ResolvedCompareSettings.cs
@@ -1,11 +1,12 @@
 using System.Collections.Immutable;
+using ParallelCompare.Core.Comparison;
 
 namespace ParallelCompare.Core.Options;
 
 public sealed record ResolvedCompareSettings
 {
     public required string LeftPath { get; init; }
-    public required string RightPath { get; init; }
+    public string? RightPath { get; init; }
     public ComparisonMode Mode { get; init; }
     public ImmutableArray<HashAlgorithmType> Algorithms { get; init; } = ImmutableArray<HashAlgorithmType>.Empty;
     public ImmutableArray<string> IgnorePatterns { get; init; } = ImmutableArray<string>.Empty;
@@ -25,4 +26,6 @@ public sealed record ResolvedCompareSettings
     public string? InteractiveTheme { get; init; }
     public string? InteractiveFilter { get; init; }
     public string? InteractiveVerbosity { get; init; }
+    public bool UsesBaseline { get; init; }
+    public BaselineMetadata? BaselineMetadata { get; init; }
 }

--- a/src/ParallelCompare.Core/Reporting/ComparisonResultExporter.cs
+++ b/src/ParallelCompare.Core/Reporting/ComparisonResultExporter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using ParallelCompare.Core.Comparison;
 
 namespace ParallelCompare.Core.Reporting;
@@ -35,7 +36,14 @@ public sealed class ComparisonResultExporter
             LeftPath = result.LeftPath,
             RightPath = result.RightPath,
             Root = ToSerializable(result.Root),
-            Summary = result.Summary
+            Summary = result.Summary,
+            Baseline = result.Baseline is null ? null : new SerializableBaselineMetadata
+            {
+                ManifestPath = result.Baseline.ManifestPath,
+                SourcePath = result.Baseline.SourcePath,
+                CreatedAt = result.Baseline.CreatedAt,
+                Algorithms = result.Baseline.Algorithms.Select(a => a.ToString()).ToArray()
+            }
         };
     }
 
@@ -67,6 +75,7 @@ public sealed class ComparisonResultExporter
         public required string RightPath { get; init; }
         public required SerializableComparisonNode Root { get; init; }
         public required ComparisonSummary Summary { get; init; }
+        public SerializableBaselineMetadata? Baseline { get; init; }
     }
 
     private sealed record SerializableComparisonNode
@@ -88,5 +97,13 @@ public sealed class ComparisonResultExporter
         public Dictionary<string, string>? LeftHashes { get; init; }
         public Dictionary<string, string>? RightHashes { get; init; }
         public string? ErrorMessage { get; init; }
+    }
+
+    private sealed record SerializableBaselineMetadata
+    {
+        public required string ManifestPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required DateTimeOffset CreatedAt { get; init; }
+        public string[]? Algorithms { get; init; }
     }
 }


### PR DESCRIPTION
## Summary
- add a baseline manifest pipeline with new core engines, resolver updates, and orchestrator wiring so `--baseline` runs work without a live right-hand tree
- update the snapshot, watch, and interactive flows to generate manifests, skip unnecessary watchers, and display baseline metadata plus watch status in both CLI and TUI outputs
- record the Phase 4 checklist items as complete

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68db02cddc24832a8e48036b1456cacd