### PR TITLE
Add filesystem abstraction and comprehensive tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-verify:
+    name: Build and verify release artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |-
+            8.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build --logger:"console;verbosity=minimal"
+
+      # - name: Publish to NuGet
+      #   env:
+      #     NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      #   run: |
+      #     dotnet pack --configuration Release --no-build
+      #     dotnet nuget push "**/*.nupkg" \
+      #       --api-key "$NUGET_API_KEY" \
+      #       --source "https://api.nuget.org/v3/index.json" \
+      #       --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Build artifacts
+bin/
+obj/
+
+# User-specific files
+*.user
+*.userosscache
+*.suo
+*.cache
+*.pdb
+*.log
+
+# Visual Studio Code
+.vscode/
+
+# Dotnet CLI
+*.deps.json
+*.runtimeconfig.json
+
+# NuGet
+*.nupkg
+.nuget/
+
+# Others
+*.DS_Store

--- a/ParallelCompare.sln
+++ b/ParallelCompare.sln
@@ -1,0 +1,54 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParallelCompare.App", "src\ParallelCompare.App\ParallelCompare.App.csproj", "{14527BDC-7947-4E7E-9496-2081FE959247}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParallelCompare.Core", "src\ParallelCompare.Core\ParallelCompare.Core.csproj", "{C8274295-6390-4EFF-B36A-98FAB09B141A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Debug|x64.Build.0 = Debug|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Debug|x86.Build.0 = Debug|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Release|x64.ActiveCfg = Release|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Release|x64.Build.0 = Release|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Release|x86.ActiveCfg = Release|Any CPU
+		{14527BDC-7947-4E7E-9496-2081FE959247}.Release|x86.Build.0 = Release|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Debug|x64.Build.0 = Debug|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Debug|x86.Build.0 = Debug|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|x64.ActiveCfg = Release|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|x64.Build.0 = Release|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|x86.ActiveCfg = Release|Any CPU
+		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{14527BDC-7947-4E7E-9496-2081FE959247} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{C8274295-6390-4EFF-B36A-98FAB09B141A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+	EndGlobalSection
+EndGlobal

--- a/ParallelCompare.sln
+++ b/ParallelCompare.sln
@@ -9,6 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParallelCompare.App", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParallelCompare.Core", "src\ParallelCompare.Core\ParallelCompare.Core.csproj", "{C8274295-6390-4EFF-B36A-98FAB09B141A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParallelCompare.Tests", "tests\ParallelCompare.Tests\ParallelCompare.Tests.csproj", "{FD64013B-2C0D-46BA-A437-673169E95657}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +47,18 @@ Global
 		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|x64.Build.0 = Release|Any CPU
 		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|x86.ActiveCfg = Release|Any CPU
 		{C8274295-6390-4EFF-B36A-98FAB09B141A}.Release|x86.Build.0 = Release|Any CPU
+		{FD64013B-2C0D-46BA-A437-673169E95657}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD64013B-2C0D-46BA-A437-673169E95657}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD64013B-2C0D-46BA-A437-673169E95657}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FD64013B-2C0D-46BA-A437-673169E95657}.Debug|x64.Build.0 = Debug|Any CPU
+		{FD64013B-2C0D-46BA-A437-673169E95657}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FD64013B-2C0D-46BA-A437-673169E95657}.Debug|x86.Build.0 = Debug|Any CPU
+		{FD64013B-2C0D-46BA-A437-673169E95657}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD64013B-2C0D-46BA-A437-673169E95657}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD64013B-2C0D-46BA-A437-673169E95657}.Release|x64.ActiveCfg = Release|Any CPU
+		{FD64013B-2C0D-46BA-A437-673169E95657}.Release|x64.Build.0 = Release|Any CPU
+		{FD64013B-2C0D-46BA-A437-673169E95657}.Release|x86.ActiveCfg = Release|Any CPU
+		{FD64013B-2C0D-46BA-A437-673169E95657}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -50,5 +66,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{14527BDC-7947-4E7E-9496-2081FE959247} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{C8274295-6390-4EFF-B36A-98FAB09B141A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{FD64013B-2C0D-46BA-A437-673169E95657} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -29,6 +29,7 @@ This checklist tracks the work required to deliver the consolidated implementati
 
 ## Documentation & Release
 - [x] Produce consolidated implementation plan.
+- [x] Configure automated release workflow.
 - [ ] Update user documentation and quickstart guides once implementation stabilizes.
 - [ ] Prepare release notes and onboarding materials for the combined feature set.
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -23,8 +23,8 @@ This checklist tracks the work required to deliver the consolidated implementati
 - [x] Surface watch status and baseline metadata in both CLI and TUI outputs.
 
 ## Phase 5 – Testing & Polishing
-- [ ] Author unit tests for configuration resolution, exporter selection, and diff-tool invocation.
-- [ ] Create integration tests for compare/watch/snapshot workflows.
+- [x] Author unit tests for configuration resolution, exporter selection, and diff-tool invocation.
+- [x] Create integration tests for compare/watch/snapshot workflows.
 - [ ] Conduct manual cross-platform validation (Windows, macOS, Linux) for TUI and CLI flows.
 
 ## Documentation & Release

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -10,12 +10,12 @@ This checklist tracks the work required to deliver the consolidated implementati
 ## Phase 2 – Tree Model Integration
 - [x] Replace flat comparison records with hierarchical `ComparisonNode` data model.
 - [x] Adapt exporters and summaries to consume the tree structure.
-- [ ] Implement adapters to stream engine updates into tree nodes for live updates.
+- [x] Implement adapters to stream engine updates into tree nodes for live updates.
 
 ## Phase 3 – Interactive Experience Upgrade
-- [ ] Embed Spectre.Console TUI from ehgdxp implementation.
-- [ ] Wire keyboard shortcuts (navigation, filters, algo toggle, exports, diff, pause/resume, help).
-- [ ] Ensure interactive mode respects configuration defaults (theme, filter, verbosity).
+- [x] Embed Spectre.Console TUI from ehgdxp implementation.
+- [x] Wire keyboard shortcuts (navigation, filters, algo toggle, exports, diff, pause/resume, help).
+- [x] Ensure interactive mode respects configuration defaults (theme, filter, verbosity).
 
 ## Phase 4 – Watch & Snapshot Enhancements
 - [ ] Merge FileSystemWatcher pipeline with new engine and TUI refresh cycle.

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,0 +1,34 @@
+# ParallelCompare Integration Checklist
+
+This checklist tracks the work required to deliver the consolidated implementation described in `docs/consolidated-implementation.md`.
+
+## Phase 1 – Foundation Merge
+- [x] Import jzl3qc command modules (`compare`, `watch`, `snapshot`, `completion`).
+- [x] Integrate configuration/profile resolver from base spec implementation.
+- [x] Standardize shared option set and exit codes across commands.
+
+## Phase 2 – Tree Model Integration
+- [x] Replace flat comparison records with hierarchical `ComparisonNode` data model.
+- [x] Adapt exporters and summaries to consume the tree structure.
+- [ ] Implement adapters to stream engine updates into tree nodes for live updates.
+
+## Phase 3 – Interactive Experience Upgrade
+- [ ] Embed Spectre.Console TUI from ehgdxp implementation.
+- [ ] Wire keyboard shortcuts (navigation, filters, algo toggle, exports, diff, pause/resume, help).
+- [ ] Ensure interactive mode respects configuration defaults (theme, filter, verbosity).
+
+## Phase 4 – Watch & Snapshot Enhancements
+- [ ] Merge FileSystemWatcher pipeline with new engine and TUI refresh cycle.
+- [ ] Support `--baseline` comparisons without requiring physical right-hand directory.
+- [ ] Surface watch status and baseline metadata in both CLI and TUI outputs.
+
+## Phase 5 – Testing & Polishing
+- [ ] Author unit tests for configuration resolution, exporter selection, and diff-tool invocation.
+- [ ] Create integration tests for compare/watch/snapshot workflows.
+- [ ] Conduct manual cross-platform validation (Windows, macOS, Linux) for TUI and CLI flows.
+
+## Documentation & Release
+- [x] Produce consolidated implementation plan.
+- [ ] Update user documentation and quickstart guides once implementation stabilizes.
+- [ ] Prepare release notes and onboarding materials for the combined feature set.
+

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -18,9 +18,9 @@ This checklist tracks the work required to deliver the consolidated implementati
 - [x] Ensure interactive mode respects configuration defaults (theme, filter, verbosity).
 
 ## Phase 4 – Watch & Snapshot Enhancements
-- [ ] Merge FileSystemWatcher pipeline with new engine and TUI refresh cycle.
-- [ ] Support `--baseline` comparisons without requiring physical right-hand directory.
-- [ ] Surface watch status and baseline metadata in both CLI and TUI outputs.
+- [x] Merge FileSystemWatcher pipeline with new engine and TUI refresh cycle.
+- [x] Support `--baseline` comparisons without requiring physical right-hand directory.
+- [x] Surface watch status and baseline metadata in both CLI and TUI outputs.
 
 ## Phase 5 – Testing & Polishing
 - [ ] Author unit tests for configuration resolution, exporter selection, and diff-tool invocation.

--- a/docs/consolidated-implementation.md
+++ b/docs/consolidated-implementation.md
@@ -1,0 +1,124 @@
+# ParallelCompare Consolidated Implementation Plan
+
+## Purpose
+
+This document merges the strongest ideas from the four proof-of-concept branches evaluated in `docs/Eval-2.md` into a single, coherent implementation strategy for the `fsEqual` tool. The goal is to satisfy the requirements in `docs/spec.md` by unifying:
+
+- The **command surface, watch mode, and snapshot/baseline workflow** of `codex/implement-plan-in-docs/spec.md-jzl3qc`.
+- The **rich Spectre.Console-driven TUI** from `codex/implement-plan-in-docs/spec.md-ehgdxp`.
+- The **configuration/profile system and validation pipeline** from `codex/implement-plan-in-docs/spec.md`.
+- The **export plumbing and supporting utilities** found in `codex/implement-plan-in-docs/spec.md-fs5wxg`.
+
+## Architectural Overview
+
+The consolidated solution is organized into four layers. Each layer borrows the most robust portion of a prior implementation and adapts it to satisfy the full spec.
+
+1. **Interface Layer**
+   - *Commands*: `compare`, `watch`, `snapshot`, and `completion` (from jzl3qc).
+   - *Interactive UI*: Spectre.Console TUI with tree navigation, filtering, exports, and keyboard shortcuts (from ehgdxp).
+   - *Progress & Logging*: Verbosity-aware console logging coupled with live progress widgets.
+
+2. **Configuration Layer**
+   - *Source Hierarchy*: CLI args → profile → config file → defaults (from base spec & fs5wxg).
+   - *Profiles*: Named presets for hash mode, ignores, exporters, diff tools.
+   - *Validation*: Centralized `SettingsValidator` enforcing path existence, option compatibility, and feature gating.
+
+3. **Comparison Engine**
+   - *Pipelines*: Enumerator → Scheduler → Worker Pool → Aggregator (from jzl3qc core).
+   - *Data Model*: Hierarchical `ComparisonNode` tree with metadata for directories and files (from ehgdxp).
+   - *Hashers*: CRC32 (default), MD5, SHA-256, XXH64 via pluggable providers.
+   - *Diff Integration*: Command-level `--diff-tool` plus interactive `D` shortcut invoking external tools.
+
+4. **Outputs & Automation**
+   - *Reports*: JSON, summary JSON, CSV, Markdown exports with shared schema (from fs5wxg + ehgdxp exporters).
+   - *Snapshots*: Persisted manifest of hashes and metadata, reused for baseline comparisons.
+   - *Watch Mode*: FileSystemWatcher driving debounced re-comparisons; integrates with TUI refresh loop.
+   - *Completion*: Spectre command app provides shell completion generation.
+
+## Feature Integration Details
+
+### CLI Commands
+- Reuse the jzl3qc command shell to ensure parity with the spec.
+- Merge option definitions to include configuration inputs (`--config`, `--profile`) and diff tooling switches.
+- Standardize exit codes (0 equal, 1 diff, 2 error) across all modes.
+
+### Configuration & Profiles
+- Adopt the resolver pipeline from the base spec implementation: parse CLI, hydrate from config, apply profile overrides, produce `ResolvedCompareSettings`.
+- Expose configuration-driven defaults for exporters, ignore patterns, watch debounce durations, and TUI preferences (theme, initial filter).
+
+### Comparison Engine & Data Model
+- Embed the hierarchical `ComparisonNode` structure from the TUI POC inside the multi-threaded engine of jzl3qc.
+- Provide adapters to translate engine events into node updates so the TUI can update in real time.
+- Ensure quick mode (mtime/size) and hash mode share the same tree representation.
+
+### Interactive Experience
+- Integrate the full key-bind set from ehgdxp (navigation, filter, algo toggle, re-run, export, verbosity, pause, help, quit).
+- Extend with watch-mode awareness: show live badges when filesystem events trigger re-runs; allow manual pause/resume from the UI.
+- Support partial re-hashing triggered by selecting a node and pressing `A`.
+
+### Watch Mode
+- Combine FileSystemWatcher logic from jzl3qc with the UI refresh pipeline from ehgdxp.
+- Provide CLI-only operation (console summary) and interactive integration (`--interactive --watch`).
+- Debounce events to avoid redundant runs; surface status in TUI footer.
+
+### Snapshot & Baseline Workflow
+- Use jzl3qc manifest serializer for `fsequal snapshot`.
+- Allow `fsequal compare <path> --baseline baseline.json` to bypass filesystem validation for the right-hand side, supporting offline comparisons.
+- Display baseline metadata within the TUI when active.
+
+### Export Pipeline
+- Consolidate exporters into a shared `IReportExporter` interface with implementations for JSON, summary JSON, CSV, and Markdown.
+- Allow multiple exporters per run; support config-driven exporter defaults.
+- Integrate interactive `E` key to invoke the same exporter infrastructure.
+
+### Logging & Diagnostics
+- Maintain verbosity-aware logger with scopes for engine stages.
+- Provide structured error messages for config issues, missing files, unsupported diff tools, or hash provider failures.
+- Capture telemetry for benchmarking hooks (optional). 
+
+### Extensibility Hooks
+- Plugin model for hash providers and exporters, auto-discovered via dependency injection.
+- Theme customization for TUI via configuration.
+- Extension points for remote compare (future roadmap) left as interfaces.
+
+## Implementation Phases
+
+1. **Foundation Merge**
+   - Import jzl3qc command shell and engine.
+   - Overlay configuration resolver from base spec implementation.
+   - Ensure compare/watch/snapshot commands compile with new settings model.
+
+2. **Tree Model Integration**
+   - Replace flat comparison results with `ComparisonNode` tree.
+   - Adjust exporters and CLI summary to consume the hierarchical model.
+
+3. **Interactive Experience Upgrade**
+   - Integrate ehgdxp Spectre UI, binding it to the new engine adapters.
+   - Wire up exporter prompts and diff tool commands.
+
+4. **Watch & Snapshot Enhancements**
+   - Bridge FileSystemWatcher events into interactive session updates.
+   - Validate baseline workflows within new configuration pipeline.
+
+5. **Testing & Polishing**
+   - Unit tests for settings resolution, exporter outputs, and diff launching.
+   - Integration tests for compare/watch/snapshot commands.
+   - Manual verification of TUI workflows on Windows, macOS, Linux.
+
+## Open Questions
+- How to harmonize progress reporting across CLI and TUI without double-rendering?
+- Should exporter plugins run in parallel or sequentially to preserve log readability?
+- What is the default behavior when both watch mode and interactive algorithm toggling queue work concurrently?
+
+## Success Metrics
+- All commands available and stable.
+- TUI supports full navigation and live refresh.
+- Configured defaults produce consistent results across CLI, TUI, watch, and snapshot modes.
+- Export outputs conform to shared schema and pass JSON schema validation.
+- Baseline comparisons and diff tool invocations succeed across platforms.
+
+## Next Steps
+- Execute Phase 1 tasks (see `docs/checklist.md`).
+- Schedule architecture review once tree model integration is complete.
+- Begin drafting user documentation and onboarding materials post-MVP.
+

--- a/src/ParallelCompare.App/Commands/CompareCommand.cs
+++ b/src/ParallelCompare.App/Commands/CompareCommand.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using ParallelCompare.App.Rendering;
+using ParallelCompare.App.Services;
+using ParallelCompare.Core.Options;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class CompareCommand : AsyncCommand<CompareCommandSettings>
+{
+    private readonly ComparisonOrchestrator _orchestrator;
+
+    public CompareCommand(ComparisonOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, CompareCommandSettings settings)
+    {
+        var input = _orchestrator.BuildInput(settings);
+        using var cancellation = new CancellationTokenSource();
+        ConsoleCancelEventHandler? handler = null;
+
+        try
+        {
+            if (input.Timeout is { } timeout)
+            {
+                cancellation.CancelAfter(timeout);
+            }
+
+            handler = (_, e) =>
+            {
+                e.Cancel = true;
+                cancellation.Cancel();
+            };
+            Console.CancelKeyPress += handler;
+
+            (var result, var resolved) = settings.NoProgress
+                ? await _orchestrator.RunAsync(input, cancellation.Token)
+                : await AnsiConsole.Status()
+                    .StartAsync("Comparing directories...", async _ => await _orchestrator.RunAsync(input, cancellation.Token));
+
+            ComparisonConsoleRenderer.RenderSummary(result);
+
+            if (settings.Interactive)
+            {
+                LaunchInteractive(result);
+            }
+            else
+            {
+                ComparisonConsoleRenderer.RenderTree(result);
+            }
+
+            return DetermineExitCode(resolved.FailOn, result);
+        }
+        catch (OperationCanceledException)
+        {
+            AnsiConsole.MarkupLine("[yellow]Comparison cancelled.[/]");
+            return 2;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything | ExceptionFormats.ShowLinks);
+            return 2;
+        }
+        finally
+        {
+            if (handler is not null)
+            {
+                Console.CancelKeyPress -= handler;
+            }
+        }
+    }
+
+    private static int DetermineExitCode(string? failOn, Core.Comparison.ComparisonResult result)
+    {
+        var summary = result.Summary;
+        var hasDifferences = summary.DifferentFiles > 0 || summary.LeftOnlyFiles > 0 || summary.RightOnlyFiles > 0;
+        var hasErrors = summary.ErrorFiles > 0;
+
+        if (hasErrors)
+        {
+            return 2;
+        }
+
+        var policy = string.IsNullOrWhiteSpace(failOn) ? "diff" : failOn.ToLowerInvariant();
+        return policy switch
+        {
+            "error" => 0,
+            "any" => hasDifferences ? 1 : 0,
+            _ => hasDifferences ? 1 : 0
+        };
+    }
+
+    private static void LaunchInteractive(Core.Comparison.ComparisonResult result)
+    {
+        var stack = new Stack<Core.Comparison.ComparisonNode>();
+        var current = result.Root;
+
+        while (true)
+        {
+            var prompt = new SelectionPrompt<InteractiveOption>()
+                .Title($"[bold]{(string.IsNullOrEmpty(current.RelativePath) ? current.Name : current.RelativePath)}[/] — select a node")
+                .PageSize(15)
+                .UseConverter(option => option.Label);
+
+            var options = BuildOptions(current, stack.Count > 0);
+            prompt.AddChoices(options);
+
+            var choice = AnsiConsole.Prompt(prompt);
+            if (choice.IsExit)
+            {
+                return;
+            }
+
+            if (choice.IsBack)
+            {
+                current = stack.Pop();
+                continue;
+            }
+
+            if (choice.Node is null)
+            {
+                continue;
+            }
+
+            if (choice.Node.NodeType == Core.Comparison.ComparisonNodeType.Directory)
+            {
+                stack.Push(current);
+                current = choice.Node;
+            }
+            else
+            {
+                DisplayFileDetail(choice.Node);
+            }
+        }
+    }
+
+    private static IEnumerable<InteractiveOption> BuildOptions(Core.Comparison.ComparisonNode node, bool canGoBack)
+    {
+        if (canGoBack)
+        {
+            yield return InteractiveOption.Back;
+        }
+
+        foreach (var child in node.Children)
+        {
+            yield return new InteractiveOption(FormatLabel(child), child, false, false);
+        }
+
+        yield return InteractiveOption.Exit;
+    }
+
+    private static string FormatLabel(Core.Comparison.ComparisonNode node)
+    {
+        var status = node.Status switch
+        {
+            Core.Comparison.ComparisonStatus.Equal => "[green]Equal[/]",
+            Core.Comparison.ComparisonStatus.Different => "[yellow]Different[/]",
+            Core.Comparison.ComparisonStatus.LeftOnly => "[blue]Left Only[/]",
+            Core.Comparison.ComparisonStatus.RightOnly => "[magenta]Right Only[/]",
+            Core.Comparison.ComparisonStatus.Error => "[red]Error[/]",
+            _ => node.Status.ToString()
+        };
+
+        return node.NodeType == Core.Comparison.ComparisonNodeType.Directory
+            ? $"{node.Name} ({status})"
+            : $"{node.Name} - {status}";
+    }
+
+    private static void DisplayFileDetail(Core.Comparison.ComparisonNode node)
+    {
+        if (node.Detail is null)
+        {
+            return;
+        }
+
+        var table = new Table().Title($"[bold]{node.Name}[/]");
+        table.AddColumn("Property");
+        table.AddColumn("Left");
+        table.AddColumn("Right");
+
+        table.AddRow("Size", node.Detail.LeftSize?.ToString() ?? "-", node.Detail.RightSize?.ToString() ?? "-");
+        table.AddRow("Modified", node.Detail.LeftModified?.ToString("u") ?? "-", node.Detail.RightModified?.ToString("u") ?? "-");
+
+        if (node.Detail.LeftHashes is not null || node.Detail.RightHashes is not null)
+        {
+            var allAlgorithms = new HashSet<HashAlgorithmType>();
+            if (node.Detail.LeftHashes is not null)
+            {
+                allAlgorithms.UnionWith(node.Detail.LeftHashes.Keys);
+            }
+
+            if (node.Detail.RightHashes is not null)
+            {
+                allAlgorithms.UnionWith(node.Detail.RightHashes.Keys);
+            }
+
+            foreach (var algorithm in allAlgorithms.OrderBy(x => x.ToString()))
+            {
+                string? leftHash = null;
+                if (node.Detail.LeftHashes is not null && node.Detail.LeftHashes.TryGetValue(algorithm, out var l))
+                {
+                    leftHash = l;
+                }
+
+                string? rightHash = null;
+                if (node.Detail.RightHashes is not null && node.Detail.RightHashes.TryGetValue(algorithm, out var r))
+                {
+                    rightHash = r;
+                }
+
+                table.AddRow($"{algorithm} Hash", leftHash ?? "-", rightHash ?? "-");
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(node.Detail.ErrorMessage))
+        {
+            table.AddRow("Error", node.Detail.ErrorMessage, node.Detail.ErrorMessage);
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.MarkupLine("[grey]Press enter to return.[/]");
+        Console.ReadLine();
+    }
+
+    private sealed record InteractiveOption(string Label, Core.Comparison.ComparisonNode? Node, bool IsExit, bool IsBack)
+    {
+        public static InteractiveOption Back { get; } = new("⬆ Back", null, false, true);
+        public static InteractiveOption Exit { get; } = new("Exit", null, true, false);
+    }
+}

--- a/src/ParallelCompare.App/Commands/CompareCommandSettings.cs
+++ b/src/ParallelCompare.App/Commands/CompareCommandSettings.cs
@@ -1,0 +1,70 @@
+using System;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public class CompareCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "<left>")]
+    public string Left { get; init; } = string.Empty;
+
+    [CommandArgument(1, "<right>")]
+    public string Right { get; init; } = string.Empty;
+
+    [CommandOption("-t|--threads")]
+    public int? Threads { get; init; }
+
+    [CommandOption("-a|--algo")]
+    public string[] Algorithms { get; init; } = Array.Empty<string>();
+
+    [CommandOption("-m|--mode")]
+    public string? Mode { get; init; }
+
+    [CommandOption("-i|--ignore")]
+    public string[] Ignore { get; init; } = Array.Empty<string>();
+
+    [CommandOption("--case-sensitive")]
+    public bool CaseSensitive { get; init; }
+
+    [CommandOption("--follow-symlinks")]
+    public bool FollowSymlinks { get; init; }
+
+    [CommandOption("--mtime-tolerance")]
+    public double? ModifiedTimeToleranceSeconds { get; init; }
+
+    [CommandOption("--baseline")]
+    public string? Baseline { get; init; }
+
+    [CommandOption("--json")]
+    public string? JsonReport { get; init; }
+
+    [CommandOption("--summary")]
+    public string? SummaryReport { get; init; }
+
+    [CommandOption("--export")]
+    public string? ExportFormat { get; init; }
+
+    [CommandOption("--no-progress")]
+    public bool NoProgress { get; init; }
+
+    [CommandOption("--diff-tool")]
+    public string? DiffTool { get; init; }
+
+    [CommandOption("--profile")]
+    public string? Profile { get; init; }
+
+    [CommandOption("--config")]
+    public string? ConfigurationPath { get; init; }
+
+    [CommandOption("--verbosity")]
+    public string? Verbosity { get; init; }
+
+    [CommandOption("--fail-on")]
+    public string? FailOn { get; init; }
+
+    [CommandOption("--timeout")]
+    public int? TimeoutSeconds { get; init; }
+
+    [CommandOption("--interactive")]
+    public bool Interactive { get; init; }
+}

--- a/src/ParallelCompare.App/Commands/CompareCommandSettings.cs
+++ b/src/ParallelCompare.App/Commands/CompareCommandSettings.cs
@@ -8,8 +8,8 @@ public class CompareCommandSettings : CommandSettings
     [CommandArgument(0, "<left>")]
     public string Left { get; init; } = string.Empty;
 
-    [CommandArgument(1, "<right>")]
-    public string Right { get; init; } = string.Empty;
+    [CommandArgument(1, "[right]")]
+    public string? Right { get; init; }
 
     [CommandOption("-t|--threads")]
     public int? Threads { get; init; }

--- a/src/ParallelCompare.App/Commands/CompletionCommand.cs
+++ b/src/ParallelCompare.App/Commands/CompletionCommand.cs
@@ -1,0 +1,46 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class CompletionCommand : Command<CompletionCommandSettings>
+{
+    public override int Execute(CommandContext context, CompletionCommandSettings settings)
+    {
+        var script = GenerateScript(settings.Shell);
+        AnsiConsole.Write(script);
+        return 0;
+    }
+
+    private static string GenerateScript(string shell)
+    {
+        return shell.ToLowerInvariant() switch
+        {
+            "bash" => BashScript,
+            "zsh" => ZshScript,
+            "pwsh" or "powershell" => PwshScript,
+            _ => BashScript
+        };
+    }
+
+    private const string BashScript = "_fsequal_completions()\n" +
+        "{\n" +
+        "    local cur prev words cword\n" +
+        "    _init_completion -n : || return\n" +
+        "    COMPREPLY=($(compgen -W \"compare watch snapshot completion --help --version\" -- \"$cur\"))\n" +
+        "}\n" +
+        "complete -F _fsequal_completions fsequal\n";
+
+    private const string ZshScript = "#compdef fsequal\n" +
+        "_fsequal_completions() {\n" +
+        "  _arguments '1: :((compare watch snapshot completion --help --version))'\n" +
+        "}\n" +
+        "compdef _fsequal_completions fsequal\n";
+
+    private const string PwshScript = "Register-ArgumentCompleter -CommandName fsequal -ScriptBlock {\n" +
+        "    param($commandName, $parameterName, $wordToComplete)\n" +
+        "    'compare','watch','snapshot','completion','--help','--version' | Where-Object { $_ -like \"$wordToComplete*\" } | ForEach-Object {\n" +
+        "        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)\n" +
+        "    }\n" +
+        "}\n";
+}

--- a/src/ParallelCompare.App/Commands/CompletionCommandSettings.cs
+++ b/src/ParallelCompare.App/Commands/CompletionCommandSettings.cs
@@ -1,0 +1,9 @@
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class CompletionCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "<shell>")]
+    public string Shell { get; init; } = "bash";
+}

--- a/src/ParallelCompare.App/Commands/SnapshotCommand.cs
+++ b/src/ParallelCompare.App/Commands/SnapshotCommand.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading;
+using ParallelCompare.App.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class SnapshotCommand : AsyncCommand<SnapshotCommandSettings>
+{
+    private readonly ComparisonOrchestrator _orchestrator;
+
+    public SnapshotCommand(ComparisonOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, SnapshotCommandSettings settings)
+    {
+        if (string.IsNullOrWhiteSpace(settings.Output))
+        {
+            AnsiConsole.MarkupLine("[red]--output is required.[/]");
+            return 2;
+        }
+
+        var input = _orchestrator.BuildInput(settings) with
+        {
+            JsonReportPath = settings.Output
+        };
+
+        using var cancellation = new CancellationTokenSource();
+        ConsoleCancelEventHandler? handler = null;
+
+        try
+        {
+            if (input.Timeout is { } timeout)
+            {
+                cancellation.CancelAfter(timeout);
+            }
+
+            handler = (_, e) =>
+            {
+                e.Cancel = true;
+                cancellation.Cancel();
+            };
+            Console.CancelKeyPress += handler;
+
+            await _orchestrator.RunAsync(input, cancellation.Token);
+            AnsiConsole.MarkupLine($"[green]Snapshot written to {settings.Output}.[/]");
+            return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            AnsiConsole.MarkupLine("[yellow]Snapshot cancelled.[/]");
+            return 2;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything | ExceptionFormats.ShowLinks);
+            return 2;
+        }
+        finally
+        {
+            if (handler is not null)
+            {
+                Console.CancelKeyPress -= handler;
+            }
+        }
+    }
+}

--- a/src/ParallelCompare.App/Commands/SnapshotCommand.cs
+++ b/src/ParallelCompare.App/Commands/SnapshotCommand.cs
@@ -23,9 +23,10 @@ public sealed class SnapshotCommand : AsyncCommand<SnapshotCommandSettings>
             return 2;
         }
 
-        var input = _orchestrator.BuildInput(settings) with
+        var baseInput = _orchestrator.BuildInput(settings);
+        var input = baseInput with
         {
-            JsonReportPath = settings.Output
+            RightPath = baseInput.LeftPath
         };
 
         using var cancellation = new CancellationTokenSource();
@@ -45,8 +46,8 @@ public sealed class SnapshotCommand : AsyncCommand<SnapshotCommandSettings>
             };
             Console.CancelKeyPress += handler;
 
-            await _orchestrator.RunAsync(input, cancellation.Token);
-            AnsiConsole.MarkupLine($"[green]Snapshot written to {settings.Output}.[/]");
+            var manifest = await _orchestrator.CreateSnapshotAsync(input, settings.Output, cancellation.Token);
+            AnsiConsole.MarkupLine($"[green]Snapshot written to {settings.Output} (captured {manifest.CreatedAt:u}).[/]");
             return 0;
         }
         catch (OperationCanceledException)

--- a/src/ParallelCompare.App/Commands/SnapshotCommandSettings.cs
+++ b/src/ParallelCompare.App/Commands/SnapshotCommandSettings.cs
@@ -1,0 +1,11 @@
+using System;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class SnapshotCommandSettings : CompareCommandSettings
+{
+    [CommandOption("--output <PATH>")]
+    public string Output { get; init; } = string.Empty;
+
+}

--- a/src/ParallelCompare.App/Commands/WatchCommand.cs
+++ b/src/ParallelCompare.App/Commands/WatchCommand.cs
@@ -2,8 +2,10 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using ParallelCompare.App.Interactive;
 using ParallelCompare.App.Rendering;
 using ParallelCompare.App.Services;
+using ParallelCompare.Core.Options;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -12,10 +14,12 @@ namespace ParallelCompare.App.Commands;
 public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
 {
     private readonly ComparisonOrchestrator _orchestrator;
+    private readonly DiffToolLauncher _diffLauncher;
 
     public WatchCommand(ComparisonOrchestrator orchestrator)
     {
         _orchestrator = orchestrator;
+        _diffLauncher = new DiffToolLauncher();
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, WatchCommandSettings settings)
@@ -39,16 +43,28 @@ public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
             Console.CancelKeyPress += handler;
 
             var resolvedRun = await _orchestrator.RunAsync(input, cancellation.Token);
-            Render(resolvedRun.Result, settings);
+
+            if (settings.Interactive)
+            {
+                await RunInteractiveAsync(resolvedRun.Result, input, resolvedRun.Resolved, settings, cancellation.Token);
+                return 0;
+            }
+
+            Render(resolvedRun.Result, resolvedRun.Resolved, settings);
 
             using var semaphore = new SemaphoreSlim(1, 1);
             using var timer = new Timer(async _ => await RunComparisonAsync(), null, Timeout.Infinite, Timeout.Infinite);
 
             using var leftWatcher = CreateWatcher(resolvedRun.Resolved.LeftPath, ScheduleRun);
-            using var rightWatcher = CreateWatcher(resolvedRun.Resolved.RightPath, ScheduleRun);
+            using FileSystemWatcher? rightWatcher = !resolvedRun.Resolved.UsesBaseline && !string.IsNullOrWhiteSpace(resolvedRun.Resolved.RightPath)
+                ? CreateWatcher(resolvedRun.Resolved.RightPath!, ScheduleRun)
+                : null;
 
             leftWatcher.EnableRaisingEvents = true;
-            rightWatcher.EnableRaisingEvents = true;
+            if (rightWatcher is not null)
+            {
+                rightWatcher.EnableRaisingEvents = true;
+            }
 
             AnsiConsole.MarkupLine("[grey]Watching for changes. Press Ctrl+C to stop.[/]");
             try
@@ -77,7 +93,7 @@ public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
                 try
                 {
                     var run = await _orchestrator.RunAsync(input, cancellation.Token);
-                    Render(run.Result, settings);
+                    Render(run.Result, run.Resolved, settings);
                 }
                 catch (OperationCanceledException)
                 {
@@ -108,6 +124,59 @@ public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
         }
     }
 
+    private async Task RunInteractiveAsync(
+        Core.Comparison.ComparisonResult result,
+        CompareSettingsInput input,
+        ResolvedCompareSettings resolved,
+        WatchCommandSettings settings,
+        CancellationToken cancellationToken)
+    {
+        var interactiveInput = input with
+        {
+            InteractiveFilter = resolved.InteractiveFilter,
+            InteractiveTheme = resolved.InteractiveTheme,
+            InteractiveVerbosity = resolved.InteractiveVerbosity
+        };
+
+        var session = new InteractiveCompareSession(_orchestrator, _diffLauncher);
+
+        using var timer = new Timer(async _ => await TriggerRefreshAsync(), null, Timeout.Infinite, Timeout.Infinite);
+
+        using var leftWatcher = CreateWatcher(resolved.LeftPath, ScheduleRun);
+        using FileSystemWatcher? rightWatcher = !resolved.UsesBaseline && !string.IsNullOrWhiteSpace(resolved.RightPath)
+            ? CreateWatcher(resolved.RightPath!, ScheduleRun)
+            : null;
+
+        leftWatcher.EnableRaisingEvents = true;
+        if (rightWatcher is not null)
+        {
+            rightWatcher.EnableRaisingEvents = true;
+        }
+
+        AnsiConsole.MarkupLine("[grey]Watching for changes. Press Ctrl+C to stop.[/]");
+
+        var initialStatus = resolved.UsesBaseline && resolved.BaselineMetadata is { } baseline
+            ? $"Watching {resolved.LeftPath} against baseline {baseline.ManifestPath}."
+            : $"Watching {resolved.LeftPath} and {resolved.RightPath}.";
+
+        await session.RunAsync(result, interactiveInput, resolved, cancellationToken, initialStatus);
+
+        return;
+
+        void ScheduleRun()
+        {
+            timer.Change(TimeSpan.FromMilliseconds(settings.DebounceMilliseconds), Timeout.InfiniteTimeSpan);
+        }
+
+        async Task TriggerRefreshAsync()
+        {
+            var timestamp = DateTimeOffset.Now.ToLocalTime().ToString("T");
+            var refreshed = $"Filesystem change detected at {timestamp}. Comparison refreshed.";
+            var paused = $"Filesystem change detected at {timestamp}, but refresh is paused.";
+            await session.QueueWatchRefreshAsync(refreshed, paused);
+        }
+    }
+
     private static FileSystemWatcher CreateWatcher(string path, Action onChange)
     {
         var watcher = new FileSystemWatcher(path)
@@ -127,10 +196,11 @@ public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
         return watcher;
     }
 
-    private static void Render(Core.Comparison.ComparisonResult result, WatchCommandSettings settings)
+    private static void Render(Core.Comparison.ComparisonResult result, ResolvedCompareSettings resolved, WatchCommandSettings settings)
     {
         AnsiConsole.Clear();
         ComparisonConsoleRenderer.RenderSummary(result);
+        ComparisonConsoleRenderer.RenderWatchStatus(result, resolved);
         if (!settings.Interactive)
         {
             ComparisonConsoleRenderer.RenderTree(result, maxDepth: 2);

--- a/src/ParallelCompare.App/Commands/WatchCommand.cs
+++ b/src/ParallelCompare.App/Commands/WatchCommand.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ParallelCompare.App.Rendering;
+using ParallelCompare.App.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
+{
+    private readonly ComparisonOrchestrator _orchestrator;
+
+    public WatchCommand(ComparisonOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, WatchCommandSettings settings)
+    {
+        var input = _orchestrator.BuildInput(settings);
+        using var cancellation = new CancellationTokenSource();
+        ConsoleCancelEventHandler? handler = null;
+
+        try
+        {
+            if (input.Timeout is { } timeout)
+            {
+                cancellation.CancelAfter(timeout);
+            }
+
+            handler = (_, e) =>
+            {
+                e.Cancel = true;
+                cancellation.Cancel();
+            };
+            Console.CancelKeyPress += handler;
+
+            var resolvedRun = await _orchestrator.RunAsync(input, cancellation.Token);
+            Render(resolvedRun.Result, settings);
+
+            using var semaphore = new SemaphoreSlim(1, 1);
+            using var timer = new Timer(async _ => await RunComparisonAsync(), null, Timeout.Infinite, Timeout.Infinite);
+
+            using var leftWatcher = CreateWatcher(resolvedRun.Resolved.LeftPath, ScheduleRun);
+            using var rightWatcher = CreateWatcher(resolvedRun.Resolved.RightPath, ScheduleRun);
+
+            leftWatcher.EnableRaisingEvents = true;
+            rightWatcher.EnableRaisingEvents = true;
+
+            AnsiConsole.MarkupLine("[grey]Watching for changes. Press Ctrl+C to stop.[/]");
+            try
+            {
+                await Task.Delay(Timeout.Infinite, cancellation.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected on cancellation
+            }
+
+            return 0;
+
+            void ScheduleRun()
+            {
+                timer.Change(TimeSpan.FromMilliseconds(settings.DebounceMilliseconds), Timeout.InfiniteTimeSpan);
+            }
+
+            async Task RunComparisonAsync()
+            {
+                if (!await semaphore.WaitAsync(0, cancellation.Token))
+                {
+                    return;
+                }
+
+                try
+                {
+                    var run = await _orchestrator.RunAsync(input, cancellation.Token);
+                    Render(run.Result, settings);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Ignore cancellation during shutdown.
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            AnsiConsole.MarkupLine("[yellow]Watch cancelled.[/]");
+            return 2;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything | ExceptionFormats.ShowLinks);
+            return 2;
+        }
+        finally
+        {
+            if (handler is not null)
+            {
+                Console.CancelKeyPress -= handler;
+            }
+        }
+    }
+
+    private static FileSystemWatcher CreateWatcher(string path, Action onChange)
+    {
+        var watcher = new FileSystemWatcher(path)
+        {
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.LastWrite
+        };
+
+        void Handler(object? sender, FileSystemEventArgs args) => onChange();
+        void RenamedHandler(object? sender, RenamedEventArgs args) => onChange();
+
+        watcher.Changed += Handler;
+        watcher.Created += Handler;
+        watcher.Deleted += Handler;
+        watcher.Renamed += RenamedHandler;
+
+        return watcher;
+    }
+
+    private static void Render(Core.Comparison.ComparisonResult result, WatchCommandSettings settings)
+    {
+        AnsiConsole.Clear();
+        ComparisonConsoleRenderer.RenderSummary(result);
+        if (!settings.Interactive)
+        {
+            ComparisonConsoleRenderer.RenderTree(result, maxDepth: 2);
+        }
+    }
+}

--- a/src/ParallelCompare.App/Commands/WatchCommandSettings.cs
+++ b/src/ParallelCompare.App/Commands/WatchCommandSettings.cs
@@ -1,0 +1,9 @@
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Commands;
+
+public sealed class WatchCommandSettings : CompareCommandSettings
+{
+    [CommandOption("--debounce <MILLISECONDS>")]
+    public int DebounceMilliseconds { get; init; } = 750;
+}

--- a/src/ParallelCompare.App/Infrastructure/TypeRegistrar.cs
+++ b/src/ParallelCompare.App/Infrastructure/TypeRegistrar.cs
@@ -1,0 +1,55 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console.Cli;
+
+namespace ParallelCompare.App.Infrastructure;
+
+public sealed class TypeRegistrar : ITypeRegistrar
+{
+    private readonly IServiceCollection _services;
+
+    public TypeRegistrar(IServiceCollection services)
+    {
+        _services = services;
+    }
+
+    public ITypeResolver Build()
+    {
+        return new TypeResolver(_services.BuildServiceProvider());
+    }
+
+    public void Register(Type service, Type implementation)
+    {
+        _services.AddSingleton(service, implementation);
+    }
+
+    public void RegisterInstance(Type service, object implementation)
+    {
+        _services.AddSingleton(service, implementation);
+    }
+
+    public void RegisterLazy(Type service, Func<object> factory)
+    {
+        _services.AddSingleton(service, _ => factory());
+    }
+
+    private sealed class TypeResolver : ITypeResolver, IDisposable
+    {
+        private readonly ServiceProvider _provider;
+
+        public TypeResolver(ServiceProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public object? Resolve(Type? type)
+        {
+            return type is null ? null : _provider.GetService(type);
+        }
+
+        public void Dispose()
+        {
+            _provider.Dispose();
+        }
+    }
+}

--- a/src/ParallelCompare.App/Interactive/InteractiveCompareSession.cs
+++ b/src/ParallelCompare.App/Interactive/InteractiveCompareSession.cs
@@ -1,0 +1,963 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ParallelCompare.App.Services;
+using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.Options;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace ParallelCompare.App.Interactive;
+
+public sealed class InteractiveCompareSession
+{
+    private readonly ComparisonOrchestrator _orchestrator;
+    private readonly DiffToolLauncher _diffLauncher;
+    private readonly InteractiveExportService _exportService = new();
+
+    private ComparisonResult _result = null!;
+    private CompareSettingsInput _input = null!;
+    private ResolvedCompareSettings _resolved = null!;
+    private InteractiveTheme _theme = InteractiveTheme.Dark;
+    private InteractiveFilter _filter = InteractiveFilter.All;
+    private InteractiveVerbosity _verbosity = InteractiveVerbosity.Info;
+    private readonly List<TreeEntry> _visibleEntries = new();
+    private TreeEntry? _rootEntry;
+    private int _selectedIndex;
+    private bool _showHelp;
+    private bool _paused;
+    private string? _statusMessage;
+    private DateTimeOffset _lastRunAt;
+    private CancellationToken _cancellationToken;
+    private readonly List<HashAlgorithmType> _algorithmTypes = new();
+    private readonly List<string> _algorithmNames = new();
+    private int _activeAlgorithmIndex;
+
+    public InteractiveCompareSession(ComparisonOrchestrator orchestrator, DiffToolLauncher diffLauncher)
+    {
+        _orchestrator = orchestrator;
+        _diffLauncher = diffLauncher;
+    }
+
+    public async Task RunAsync(
+        ComparisonResult result,
+        CompareSettingsInput input,
+        ResolvedCompareSettings resolved,
+        CancellationToken cancellationToken)
+    {
+        _result = result;
+        _input = input with { EnableInteractive = true };
+        _resolved = resolved;
+        _cancellationToken = cancellationToken;
+        _theme = InteractiveTheme.Parse(resolved.InteractiveTheme);
+        _filter = InteractiveFilterExtensions.Parse(resolved.InteractiveFilter);
+        _verbosity = InteractiveVerbosityExtensions.Parse(resolved.InteractiveVerbosity);
+        _showHelp = false;
+        _paused = false;
+        _statusMessage = null;
+        _lastRunAt = DateTimeOffset.UtcNow;
+
+        UpdateAlgorithmList(_input.Algorithm);
+        BuildTree();
+
+        var cursorManaged = false;
+        bool previousCursor = false;
+        try
+        {
+#pragma warning disable CA1416
+            previousCursor = Console.CursorVisible;
+            Console.CursorVisible = false;
+#pragma warning restore CA1416
+            cursorManaged = true;
+        }
+        catch (PlatformNotSupportedException)
+        {
+            cursorManaged = false;
+        }
+
+        try
+        {
+            Render();
+
+            while (true)
+            {
+                if (_cancellationToken.IsCancellationRequested)
+                {
+                    SetStatus("Cancellation requested.");
+                    break;
+                }
+
+                var key = Console.ReadKey(intercept: true);
+                if (await HandleKeyAsync(key))
+                {
+                    break;
+                }
+
+                Render();
+            }
+        }
+        finally
+        {
+            if (cursorManaged)
+            {
+#pragma warning disable CA1416
+                Console.CursorVisible = previousCursor;
+#pragma warning restore CA1416
+            }
+        }
+    }
+
+    private async Task<bool> HandleKeyAsync(ConsoleKeyInfo key)
+    {
+        switch (key.Key)
+        {
+            case ConsoleKey.Q:
+            case ConsoleKey.Escape:
+                return true;
+            case ConsoleKey.UpArrow:
+                MoveSelection(-1);
+                break;
+            case ConsoleKey.DownArrow:
+                MoveSelection(1);
+                break;
+            case ConsoleKey.LeftArrow:
+                HandleCollapse();
+                break;
+            case ConsoleKey.RightArrow:
+                HandleExpand();
+                break;
+            case ConsoleKey.PageUp:
+                MoveSelection(-10);
+                break;
+            case ConsoleKey.PageDown:
+                MoveSelection(10);
+                break;
+            case ConsoleKey.Home:
+                MoveToIndex(0);
+                break;
+            case ConsoleKey.End:
+                MoveToIndex(_visibleEntries.Count - 1);
+                break;
+            case ConsoleKey.Enter:
+            case ConsoleKey.Spacebar:
+                ToggleExpansion();
+                break;
+            case ConsoleKey.F:
+                await HandleFilterAsync();
+                break;
+            case ConsoleKey.A:
+                await HandleAlgorithmAsync();
+                break;
+            case ConsoleKey.R:
+                await HandleRerunAsync();
+                break;
+            case ConsoleKey.E:
+                await HandleExportAsync();
+                break;
+            case ConsoleKey.D:
+                HandleDiff();
+                break;
+            case ConsoleKey.P:
+                TogglePause();
+                break;
+            case ConsoleKey.L:
+                CycleVerbosity();
+                break;
+            default:
+                if (key.KeyChar == '?')
+                {
+                    _showHelp = !_showHelp;
+                    SetStatus(_showHelp ? "Help shown." : "Help hidden.");
+                }
+
+                break;
+        }
+
+        return false;
+    }
+
+    private void Render()
+    {
+        AnsiConsole.Clear();
+
+        var layout = new Layout("root")
+            .SplitRows(
+                new Layout("header").Size(7),
+                new Layout("body"),
+                new Layout("footer").Size(_showHelp ? 8 : 4));
+
+        layout["header"].Update(RenderHeader());
+
+        var body = new Layout("body-root")
+            .SplitColumns(
+                new Layout("tree").Ratio(2),
+                new Layout("detail").Ratio(3));
+
+        body["tree"].Update(RenderTree());
+        body["detail"].Update(RenderDetails());
+        layout["body"].Update(body);
+
+        layout["footer"].Update(RenderFooter());
+
+        AnsiConsole.Write(layout);
+    }
+
+    private IRenderable RenderHeader()
+    {
+        var summary = _result.Summary;
+        var activeAlgorithm = GetActiveAlgorithmName();
+
+        var grid = new Grid();
+        grid.AddColumn(new GridColumn().Width(Math.Max(20, Math.Min(AnsiConsole.Profile.Width / 2, 60))));
+        grid.AddColumn();
+
+        grid.AddRow(
+            new Markup($"[bold]{Markup.Escape(_result.LeftPath)}[/]"),
+            new Markup($"[bold]{Markup.Escape(_result.RightPath)}[/]"));
+
+        grid.AddRow(
+            new Markup($"Mode: [ {_theme.Accent}]{_resolved.Mode}[/]  Algorithm: [ {_theme.Accent}]{activeAlgorithm}[/]  Threads: {FormatThreads()}"),
+            new Markup($"Filter: [ {_theme.Accent}]{_filter.ToDisplayName()}[/]  Verbosity: [ {_theme.Accent}]{_verbosity.ToDisplayName()}[/]  {( _paused ? "[yellow]Paused[/]" : "[green]Active[/]" )}"));
+
+        grid.AddRow(
+            new Markup($"Total: {summary.TotalFiles}  [ {_theme.Equal}]{summary.EqualFiles} equal[/]  [ {_theme.Different}]{summary.DifferentFiles} diff[/]  [ {_theme.LeftOnly}]{summary.LeftOnlyFiles} left[/]  [ {_theme.RightOnly}]{summary.RightOnlyFiles} right[/]  [ {_theme.Error}]{summary.ErrorFiles} error[/]"),
+            new Markup($"Updated: {_lastRunAt:HH:mm:ss}  Diff tool: {FormatDiffTool()}"));
+
+        return new Panel(grid)
+            .Border(BoxBorder.Rounded)
+            .Header(" Comparison ");
+    }
+
+    private IRenderable RenderTree()
+    {
+        var table = new Table
+        {
+            Border = TableBorder.None
+        };
+
+        table.AddColumn(new TableColumn(new Markup("[bold]Tree[/]")) { NoWrap = true });
+
+        foreach (var entry in _visibleEntries)
+        {
+            table.AddRow(new Markup(BuildTreeRow(entry)));
+        }
+
+        return new Panel(table)
+            .Border(BoxBorder.Rounded)
+            .Header($" Tree ({_visibleEntries.Count}) ");
+    }
+
+    private IRenderable RenderDetails()
+    {
+        var entry = GetSelectedEntry();
+        return entry.Node.NodeType == ComparisonNodeType.Directory
+            ? RenderDirectoryDetail(entry)
+            : RenderFileDetail(entry.Node);
+    }
+
+    private IRenderable RenderDirectoryDetail(TreeEntry entry)
+    {
+        var counts = InitializeStatusCounts();
+        CountDescendants(entry.Node, counts);
+
+        var table = new Table
+        {
+            Border = TableBorder.None
+        };
+        table.AddColumn(new TableColumn("Status"));
+        table.AddColumn(new TableColumn("Count"));
+
+        foreach (var pair in counts)
+        {
+            table.AddRow(new Markup($"{GetStatusGlyph(pair.Key)} {pair.Key}"), new Markup(pair.Value.ToString()));
+        }
+
+        var highlights = entry.Node.Children
+            .Where(child => child.Status != ComparisonStatus.Equal)
+            .Take(5)
+            .Select(child => $"{GetStatusGlyph(child.Status)} {Markup.Escape(child.Name)}");
+
+        var content = new Grid();
+        content.AddColumn();
+        content.AddRow(table);
+
+        if (highlights.Any())
+        {
+            content.AddRow(new Markup("[bold]Highlighted Children[/]"));
+            content.AddRow(new Markup(string.Join(Environment.NewLine, highlights)));
+        }
+
+        return new Panel(content)
+            .Border(BoxBorder.Rounded)
+            .Header($" Directory — {Markup.Escape(GetNodePath(entry.Node))} ");
+    }
+
+    private IRenderable RenderFileDetail(ComparisonNode node)
+    {
+        if (node.Detail is null)
+        {
+            return new Panel(new Markup("No file details available."))
+                .Border(BoxBorder.Rounded)
+                .Header($" File — {Markup.Escape(GetNodePath(node))} ");
+        }
+
+        var table = new Table
+        {
+            Border = TableBorder.None
+        };
+        table.AddColumn("Property");
+        table.AddColumn("Left");
+        table.AddColumn("Right");
+
+        table.AddRow("Size", FormatSize(node.Detail.LeftSize), FormatSize(node.Detail.RightSize));
+        table.AddRow("Modified", FormatDate(node.Detail.LeftModified), FormatDate(node.Detail.RightModified));
+
+        var algorithms = GetAlgorithms(node.Detail);
+        var active = GetActiveAlgorithmType();
+
+        foreach (var algorithm in algorithms)
+        {
+            string? leftHash = null;
+            if (node.Detail.LeftHashes is not null)
+            {
+                node.Detail.LeftHashes.TryGetValue(algorithm, out leftHash);
+            }
+
+            string? rightHash = null;
+            if (node.Detail.RightHashes is not null)
+            {
+                node.Detail.RightHashes.TryGetValue(algorithm, out rightHash);
+            }
+
+            var label = algorithm.ToString();
+            if (active == algorithm)
+            {
+                label = $"[{_theme.Accent}]{label}[/]";
+            }
+
+            table.AddRow($"{label} Hash", leftHash ?? "-", rightHash ?? "-");
+        }
+
+        if (!string.IsNullOrWhiteSpace(node.Detail.ErrorMessage))
+        {
+            table.AddRow("Error", node.Detail.ErrorMessage, node.Detail.ErrorMessage);
+        }
+
+        return new Panel(table)
+            .Border(BoxBorder.Rounded)
+            .Header($" File — {Markup.Escape(GetNodePath(node))} ");
+    }
+
+    private IRenderable RenderFooter()
+    {
+        var grid = new Grid();
+        grid.AddColumn();
+
+        grid.AddRow(new Markup($"[{_theme.Muted}]↑/↓ Move  ← Collapse  → Expand  Enter Toggle  F Filter  A Algorithm  R Re-run  E Export  D Diff  P Pause  L Verbosity  ? Help  Q Quit[/]"));
+
+        if (!string.IsNullOrWhiteSpace(_statusMessage))
+        {
+            grid.AddRow(new Markup($"[{_theme.Accent}]{Markup.Escape(_statusMessage)}[/]"));
+        }
+
+        if (_showHelp)
+        {
+            grid.AddRow(new Markup("[bold]Shortcuts[/]"));
+            grid.AddRow(new Markup(string.Join(Environment.NewLine, new[]
+            {
+                "F — Choose filter by status",
+                "A — Switch active hash algorithm and re-run",
+                "R — Re-run the comparison",
+                "E — Export current view to json/csv/markdown",
+                "D — Launch configured diff tool for the selected file",
+                "P — Toggle pause banner",
+                "L — Cycle verbosity levels",
+                "Q — Quit interactive mode"
+            })));
+        }
+
+        return new Panel(grid)
+            .Border(BoxBorder.Rounded)
+            .Header(" Controls ");
+    }
+
+    private void BuildTree(string? preservePath = null)
+    {
+        _rootEntry = BuildEntry(_result.Root, null, 0);
+        RefreshVisibleEntries(preservePath ?? _rootEntry.Path);
+    }
+
+    private TreeEntry BuildEntry(ComparisonNode node, TreeEntry? parent, int depth)
+    {
+        var entry = new TreeEntry(node, parent, depth, GetNodePath(node))
+        {
+            Expanded = depth == 0
+        };
+
+        foreach (var child in node.Children)
+        {
+            entry.Children.Add(BuildEntry(child, entry, depth + 1));
+        }
+
+        return entry;
+    }
+
+    private void RefreshVisibleEntries(string? preservePath)
+    {
+        _visibleEntries.Clear();
+
+        if (_rootEntry is null)
+        {
+            return;
+        }
+
+        var buffer = new List<TreeEntry>();
+        AppendVisible(_rootEntry, buffer);
+        _visibleEntries.AddRange(buffer);
+
+        if (_visibleEntries.Count == 0)
+        {
+            _selectedIndex = 0;
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(preservePath))
+        {
+            var index = _visibleEntries.FindIndex(entry => string.Equals(entry.Path, preservePath, StringComparison.OrdinalIgnoreCase));
+            if (index >= 0)
+            {
+                _selectedIndex = index;
+                return;
+            }
+        }
+
+        if (_selectedIndex >= _visibleEntries.Count)
+        {
+            _selectedIndex = _visibleEntries.Count - 1;
+        }
+
+        if (_selectedIndex < 0)
+        {
+            _selectedIndex = 0;
+        }
+    }
+
+    private bool AppendVisible(TreeEntry entry, List<TreeEntry> list)
+    {
+        var childEntries = new List<TreeEntry>();
+        var hasVisibleChild = false;
+
+        foreach (var child in entry.Children)
+        {
+            var childBuffer = new List<TreeEntry>();
+            if (AppendVisible(child, childBuffer))
+            {
+                hasVisibleChild = true;
+                childEntries.AddRange(childBuffer);
+            }
+        }
+
+        var include = entry == _rootEntry || MatchesFilter(entry.Node) || hasVisibleChild;
+        if (!include)
+        {
+            return false;
+        }
+
+        list.Add(entry);
+
+        if (entry.Expanded)
+        {
+            list.AddRange(childEntries);
+        }
+
+        return true;
+    }
+
+    private void MoveSelection(int offset)
+    {
+        if (_visibleEntries.Count == 0)
+        {
+            return;
+        }
+
+        var index = Math.Clamp(_selectedIndex + offset, 0, _visibleEntries.Count - 1);
+        _selectedIndex = index;
+    }
+
+    private void MoveToIndex(int index)
+    {
+        if (_visibleEntries.Count == 0)
+        {
+            return;
+        }
+
+        _selectedIndex = Math.Clamp(index, 0, _visibleEntries.Count - 1);
+    }
+
+    private void HandleCollapse()
+    {
+        var entry = GetSelectedEntry();
+        if (entry.Node.NodeType == ComparisonNodeType.Directory && entry.Expanded)
+        {
+            entry.Expanded = false;
+            RefreshVisibleEntries(entry.Path);
+            return;
+        }
+
+        if (entry.Parent is not null)
+        {
+            var parentIndex = _visibleEntries.FindIndex(e => ReferenceEquals(e, entry.Parent));
+            if (parentIndex >= 0)
+            {
+                _selectedIndex = parentIndex;
+            }
+        }
+    }
+
+    private void HandleExpand()
+    {
+        var entry = GetSelectedEntry();
+        if (entry.Node.NodeType != ComparisonNodeType.Directory)
+        {
+            return;
+        }
+
+        if (!entry.Expanded)
+        {
+            entry.Expanded = true;
+            RefreshVisibleEntries(entry.Path);
+        }
+        else
+        {
+            var child = _visibleEntries.FirstOrDefault(e => ReferenceEquals(e.Parent, entry));
+            if (child is not null)
+            {
+                var index = _visibleEntries.IndexOf(child);
+                if (index >= 0)
+                {
+                    _selectedIndex = index;
+                }
+            }
+        }
+    }
+
+    private void ToggleExpansion()
+    {
+        var entry = GetSelectedEntry();
+        if (entry.Node.NodeType != ComparisonNodeType.Directory)
+        {
+            return;
+        }
+
+        entry.Expanded = !entry.Expanded;
+        RefreshVisibleEntries(entry.Path);
+    }
+
+    private async Task HandleFilterAsync()
+    {
+        var prompt = new SelectionPrompt<InteractiveFilter>()
+            .Title("Select filter")
+            .UseConverter(filter => filter.ToDisplayName());
+
+        prompt.AddChoices(Enum.GetValues<InteractiveFilter>());
+
+        var choice = AnsiConsole.Prompt(prompt);
+        _filter = choice;
+        RefreshVisibleEntries(GetSelectedEntry().Path);
+        SetStatus($"Filter set to {choice.ToDisplayName()}.");
+        await Task.CompletedTask;
+    }
+
+    private async Task HandleAlgorithmAsync()
+    {
+        if (_algorithmNames.Count <= 1)
+        {
+            SetStatus("Only one algorithm is configured.");
+            return;
+        }
+
+        var prompt = new SelectionPrompt<string>()
+            .Title("Select hash algorithm")
+            .AddChoices(_algorithmNames);
+
+        var choice = AnsiConsole.Prompt(prompt);
+        var index = _algorithmNames.FindIndex(name => name.Equals(choice, StringComparison.OrdinalIgnoreCase));
+        if (index < 0 || index == _activeAlgorithmIndex)
+        {
+            SetStatus($"Algorithm already set to {choice}.");
+            return;
+        }
+
+        await ReRunComparisonAsync(input => input with
+        {
+            Algorithm = choice,
+            AdditionalAlgorithms = ImmutableArray<string>.Empty
+        });
+
+        _activeAlgorithmIndex = index;
+        SetStatus($"Re-ran comparison with {choice}.");
+    }
+
+    private async Task HandleRerunAsync()
+    {
+        await ReRunComparisonAsync(static input => input);
+        SetStatus("Comparison refreshed.");
+    }
+
+    private async Task HandleExportAsync()
+    {
+        var nodes = CollectFilteredNodes();
+        if (nodes.Count == 0)
+        {
+            SetStatus("Nothing to export for the current filter.");
+            return;
+        }
+
+        var format = AnsiConsole.Prompt(new SelectionPrompt<string>()
+            .Title("Select export format")
+            .AddChoices("json", "csv", "markdown"));
+
+        var destination = AnsiConsole.Ask<string>("Enter output path:");
+
+        try
+        {
+            await _exportService.ExportAsync(
+                _result,
+                nodes,
+                format,
+                destination,
+                GetActiveAlgorithmType(),
+                _cancellationToken);
+
+            SetStatus($"Exported {nodes.Count} entries to {destination}.");
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Export cancelled.");
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Export failed: {ex.Message}");
+        }
+    }
+
+    private void HandleDiff()
+    {
+        var entry = GetSelectedEntry();
+        if (entry.Node.NodeType != ComparisonNodeType.File)
+        {
+            SetStatus("Select a file to launch the diff tool.");
+            return;
+        }
+
+        if (entry.Node.Status is ComparisonStatus.LeftOnly or ComparisonStatus.RightOnly)
+        {
+            SetStatus("Diff is only available when both files exist.");
+            return;
+        }
+
+        var diffTool = _resolved.DiffTool;
+        var leftPath = Path.Combine(_result.LeftPath, entry.Node.RelativePath);
+        var rightPath = Path.Combine(_result.RightPath, entry.Node.RelativePath);
+
+        var (success, message) = _diffLauncher.TryLaunch(diffTool, leftPath, rightPath);
+        SetStatus(message);
+
+        if (!success && diffTool is null)
+        {
+            SetStatus("Configure a diff tool via --diff-tool or configuration to enable this shortcut.");
+        }
+    }
+
+    private void TogglePause()
+    {
+        _paused = !_paused;
+        SetStatus(_paused ? "Session paused." : "Session resumed.");
+    }
+
+    private void CycleVerbosity()
+    {
+        _verbosity = _verbosity.Next();
+        SetStatus($"Verbosity set to {_verbosity.ToDisplayName()}.");
+    }
+
+    private async Task ReRunComparisonAsync(Func<CompareSettingsInput, CompareSettingsInput> mutate)
+    {
+        try
+        {
+            var previousPath = GetSelectedEntry().Path;
+            var updatedInput = mutate(_input) with
+            {
+                EnableInteractive = true,
+                InteractiveFilter = _input.InteractiveFilter,
+                InteractiveTheme = _input.InteractiveTheme,
+                InteractiveVerbosity = _input.InteractiveVerbosity
+            };
+
+            await AnsiConsole.Status()
+                .StartAsync("Running comparison...", async _ =>
+                {
+                    var run = await _orchestrator.RunAsync(updatedInput, _cancellationToken);
+                    _result = run.Result;
+                    _resolved = run.Resolved;
+                    _input = updatedInput;
+                    _lastRunAt = DateTimeOffset.UtcNow;
+                    UpdateAlgorithmList(_input.Algorithm);
+                    BuildTree(previousPath);
+                });
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Comparison cancelled.");
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Comparison failed: {ex.Message}");
+        }
+    }
+
+    private void UpdateAlgorithmList(string? preferred)
+    {
+        _algorithmTypes.Clear();
+        _algorithmNames.Clear();
+
+        if (!_resolved.Algorithms.IsDefaultOrEmpty)
+        {
+            foreach (var algorithm in _resolved.Algorithms)
+            {
+                _algorithmTypes.Add(algorithm);
+                _algorithmNames.Add(NormalizeAlgorithmName(algorithm));
+            }
+        }
+
+        if (_algorithmNames.Count == 0)
+        {
+            var fallback = _resolved.Mode == ComparisonMode.Hash ? HashAlgorithmType.Sha256 : HashAlgorithmType.Crc32;
+            _algorithmTypes.Add(fallback);
+            _algorithmNames.Add(NormalizeAlgorithmName(fallback));
+        }
+
+        if (!string.IsNullOrWhiteSpace(preferred))
+        {
+            var index = _algorithmNames.FindIndex(name => name.Equals(preferred, StringComparison.OrdinalIgnoreCase));
+            if (index >= 0)
+            {
+                _activeAlgorithmIndex = index;
+                return;
+            }
+        }
+
+        if (_activeAlgorithmIndex >= _algorithmNames.Count || _activeAlgorithmIndex < 0)
+        {
+            _activeAlgorithmIndex = 0;
+        }
+    }
+
+    private TreeEntry GetSelectedEntry()
+    {
+        if (_visibleEntries.Count == 0)
+        {
+            return _rootEntry ?? throw new InvalidOperationException("Tree has not been initialized.");
+        }
+
+        _selectedIndex = Math.Clamp(_selectedIndex, 0, _visibleEntries.Count - 1);
+        return _visibleEntries[_selectedIndex];
+    }
+
+    private List<ComparisonNode> CollectFilteredNodes()
+    {
+        var nodes = new List<ComparisonNode>();
+
+        void Visit(ComparisonNode node)
+        {
+            if (MatchesFilter(node))
+            {
+                nodes.Add(node);
+            }
+
+            foreach (var child in node.Children)
+            {
+                Visit(child);
+            }
+        }
+
+        Visit(_result.Root);
+        return nodes;
+    }
+
+    private bool MatchesFilter(ComparisonNode node)
+        => _filter switch
+        {
+            InteractiveFilter.All => true,
+            InteractiveFilter.Differences => node.Status is ComparisonStatus.Different or ComparisonStatus.LeftOnly or ComparisonStatus.RightOnly or ComparisonStatus.Error,
+            InteractiveFilter.LeftOnly => node.Status == ComparisonStatus.LeftOnly,
+            InteractiveFilter.RightOnly => node.Status == ComparisonStatus.RightOnly,
+            InteractiveFilter.Errors => node.Status == ComparisonStatus.Error,
+            _ => true
+        };
+
+    private static Dictionary<ComparisonStatus, int> InitializeStatusCounts()
+        => new()
+        {
+            [ComparisonStatus.Equal] = 0,
+            [ComparisonStatus.Different] = 0,
+            [ComparisonStatus.LeftOnly] = 0,
+            [ComparisonStatus.RightOnly] = 0,
+            [ComparisonStatus.Error] = 0
+        };
+
+    private static void CountDescendants(ComparisonNode node, IDictionary<ComparisonStatus, int> counts)
+    {
+        if (node.NodeType == ComparisonNodeType.File)
+        {
+            counts[node.Status] = counts[node.Status] + 1;
+            return;
+        }
+
+        foreach (var child in node.Children)
+        {
+            CountDescendants(child, counts);
+        }
+    }
+
+    private IEnumerable<HashAlgorithmType> GetAlgorithms(FileComparisonDetail detail)
+    {
+        var set = new HashSet<HashAlgorithmType>();
+        if (detail.LeftHashes is not null)
+        {
+            foreach (var key in detail.LeftHashes.Keys)
+            {
+                set.Add(key);
+            }
+        }
+
+        if (detail.RightHashes is not null)
+        {
+            foreach (var key in detail.RightHashes.Keys)
+            {
+                set.Add(key);
+            }
+        }
+
+        return set.OrderBy(algorithm => algorithm.ToString(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private string BuildTreeRow(TreeEntry entry)
+    {
+        var indent = new string(' ', entry.Depth * 2);
+        var expander = entry.Node.NodeType == ComparisonNodeType.Directory
+            ? $"[{_theme.Muted}]{(entry.Expanded ? '▾' : '▸')}[/]"
+            : " ";
+        var status = GetStatusGlyph(entry.Node.Status);
+        var nameColor = GetStatusColor(entry.Node.Status);
+        var nameMarkup = $"[{nameColor}]{Markup.Escape(entry.Node.Name)}[/]";
+
+        var row = $"{indent}{expander} {status} {nameMarkup}";
+        if (ReferenceEquals(entry, GetSelectedEntry()))
+        {
+            row = $"[reverse]{row}[/]";
+        }
+
+        return row;
+    }
+
+    private string GetStatusGlyph(ComparisonStatus status)
+        => status switch
+        {
+            ComparisonStatus.Equal => $"[{_theme.Equal}]✓[/]",
+            ComparisonStatus.Different => $"[{_theme.Different}]![/]",
+            ComparisonStatus.LeftOnly => $"[{_theme.LeftOnly}]←[/]",
+            ComparisonStatus.RightOnly => $"[{_theme.RightOnly}]→[/]",
+            ComparisonStatus.Error => $"[{_theme.Error}]?[/]",
+            _ => status.ToString()
+        };
+
+    private string GetStatusColor(ComparisonStatus status)
+        => status switch
+        {
+            ComparisonStatus.Equal => _theme.Equal,
+            ComparisonStatus.Different => _theme.Different,
+            ComparisonStatus.LeftOnly => _theme.LeftOnly,
+            ComparisonStatus.RightOnly => _theme.RightOnly,
+            ComparisonStatus.Error => _theme.Error,
+            _ => _theme.Muted
+        };
+
+    private static string GetNodePath(ComparisonNode node)
+        => string.IsNullOrWhiteSpace(node.RelativePath)
+            ? node.Name
+            : node.RelativePath.Replace(Path.DirectorySeparatorChar, '/');
+
+    private static string FormatSize(long? value)
+        => value is null ? "-" : value.Value.ToString("N0");
+
+    private static string FormatDate(DateTimeOffset? value)
+        => value is null ? "-" : value.Value.ToString("u");
+
+    private string GetActiveAlgorithmName()
+    {
+        if (_algorithmNames.Count == 0)
+        {
+            return "n/a";
+        }
+
+        _activeAlgorithmIndex = Math.Clamp(_activeAlgorithmIndex, 0, _algorithmNames.Count - 1);
+        return _algorithmNames[_activeAlgorithmIndex];
+    }
+
+    private HashAlgorithmType? GetActiveAlgorithmType()
+    {
+        if (_algorithmTypes.Count == 0)
+        {
+            return null;
+        }
+
+        _activeAlgorithmIndex = Math.Clamp(_activeAlgorithmIndex, 0, _algorithmTypes.Count - 1);
+        return _algorithmTypes[_activeAlgorithmIndex];
+    }
+
+    private static string NormalizeAlgorithmName(HashAlgorithmType algorithm)
+        => algorithm switch
+        {
+            HashAlgorithmType.Crc32 => "crc32",
+            HashAlgorithmType.Md5 => "md5",
+            HashAlgorithmType.Sha256 => "sha256",
+            HashAlgorithmType.XxHash64 => "xxhash64",
+            _ => algorithm.ToString().ToLowerInvariant()
+        };
+
+    private string FormatThreads()
+        => _resolved.Threads?.ToString() ?? "auto";
+
+    private string FormatDiffTool()
+        => string.IsNullOrWhiteSpace(_resolved.DiffTool)
+            ? "not configured"
+            : _resolved.DiffTool!;
+
+    private void SetStatus(string message)
+    {
+        _statusMessage = message;
+    }
+
+    private sealed class TreeEntry
+    {
+        public TreeEntry(ComparisonNode node, TreeEntry? parent, int depth, string path)
+        {
+            Node = node;
+            Parent = parent;
+            Depth = depth;
+            Path = path;
+        }
+
+        public ComparisonNode Node { get; }
+        public TreeEntry? Parent { get; }
+        public int Depth { get; }
+        public string Path { get; }
+        public bool Expanded { get; set; }
+        public List<TreeEntry> Children { get; } = new();
+    }
+}

--- a/src/ParallelCompare.App/Interactive/InteractiveExportService.cs
+++ b/src/ParallelCompare.App/Interactive/InteractiveExportService.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.App.Interactive;
+
+public sealed class InteractiveExportService
+{
+    private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    public async Task ExportAsync(
+        ComparisonResult result,
+        IReadOnlyList<ComparisonNode> nodes,
+        string format,
+        string destination,
+        HashAlgorithmType? activeAlgorithm,
+        CancellationToken cancellationToken)
+    {
+        if (nodes.Count == 0)
+        {
+            throw new InvalidOperationException("There are no nodes to export for the current filter.");
+        }
+
+        var fullPath = Path.GetFullPath(destination);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath) ?? Directory.GetCurrentDirectory());
+
+        switch (format.Trim().ToLowerInvariant())
+        {
+            case "json":
+                await ExportJsonAsync(result, nodes, fullPath, cancellationToken);
+                break;
+            case "csv":
+                await ExportCsvAsync(result, nodes, fullPath, activeAlgorithm, cancellationToken);
+                break;
+            case "markdown":
+            case "md":
+                await ExportMarkdownAsync(result, nodes, fullPath, activeAlgorithm, cancellationToken);
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported export format '{format}'.");
+        }
+    }
+
+    private async Task ExportJsonAsync(
+        ComparisonResult result,
+        IReadOnlyList<ComparisonNode> nodes,
+        string destination,
+        CancellationToken cancellationToken)
+    {
+        await using var stream = File.Create(destination);
+        var payload = new
+        {
+            generatedAt = DateTimeOffset.UtcNow,
+            result.LeftPath,
+            result.RightPath,
+            nodes = nodes.Select(node => new
+            {
+                path = GetNodePath(node),
+                type = node.NodeType.ToString(),
+                status = node.Status.ToString(),
+                detail = node.Detail is null
+                    ? null
+                    : new
+                    {
+                        node.Detail.LeftSize,
+                        node.Detail.RightSize,
+                        node.Detail.LeftModified,
+                        node.Detail.RightModified,
+                        LeftHashes = node.Detail.LeftHashes?.ToDictionary(pair => pair.Key.ToString(), pair => pair.Value),
+                        RightHashes = node.Detail.RightHashes?.ToDictionary(pair => pair.Key.ToString(), pair => pair.Value),
+                        node.Detail.ErrorMessage
+                    }
+            }).ToList()
+        };
+
+        await JsonSerializer.SerializeAsync(stream, payload, _jsonOptions, cancellationToken);
+    }
+
+    private async Task ExportCsvAsync(
+        ComparisonResult result,
+        IReadOnlyList<ComparisonNode> nodes,
+        string destination,
+        HashAlgorithmType? activeAlgorithm,
+        CancellationToken cancellationToken)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Path,Type,Status,LeftSize,RightSize,LeftModified,RightModified,LeftHash,RightHash,Error");
+
+        foreach (var node in nodes)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var detail = node.Detail;
+            var leftHash = detail is null ? string.Empty : GetHash(detail.LeftHashes, activeAlgorithm);
+            var rightHash = detail is null ? string.Empty : GetHash(detail.RightHashes, activeAlgorithm);
+            var error = detail?.ErrorMessage ?? string.Empty;
+
+            builder.AppendLine(string.Join(',', new[]
+            {
+                EscapeCsv(GetNodePath(node)),
+                EscapeCsv(node.NodeType.ToString()),
+                EscapeCsv(node.Status.ToString()),
+                EscapeCsv(detail?.LeftSize?.ToString() ?? string.Empty),
+                EscapeCsv(detail?.RightSize?.ToString() ?? string.Empty),
+                EscapeCsv(detail?.LeftModified?.ToString("u") ?? string.Empty),
+                EscapeCsv(detail?.RightModified?.ToString("u") ?? string.Empty),
+                EscapeCsv(leftHash ?? string.Empty),
+                EscapeCsv(rightHash ?? string.Empty),
+                EscapeCsv(error)
+            }));
+        }
+
+        await File.WriteAllTextAsync(destination, builder.ToString(), cancellationToken);
+    }
+
+    private async Task ExportMarkdownAsync(
+        ComparisonResult result,
+        IReadOnlyList<ComparisonNode> nodes,
+        string destination,
+        HashAlgorithmType? activeAlgorithm,
+        CancellationToken cancellationToken)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"# ParallelCompare Export");
+        builder.AppendLine();
+        builder.AppendLine($"- Left: `{EscapeMarkdown(result.LeftPath)}`");
+        builder.AppendLine($"- Right: `{EscapeMarkdown(result.RightPath)}`");
+        builder.AppendLine($"- Generated: {DateTimeOffset.UtcNow:u}");
+        builder.AppendLine();
+        builder.AppendLine("| Path | Type | Status | Left Size | Right Size | Left Modified | Right Modified | Left Hash | Right Hash | Error |");
+        builder.AppendLine("| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |");
+
+        foreach (var node in nodes)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var detail = node.Detail;
+            var leftHash = detail is null ? string.Empty : GetHash(detail.LeftHashes, activeAlgorithm) ?? string.Empty;
+            var rightHash = detail is null ? string.Empty : GetHash(detail.RightHashes, activeAlgorithm) ?? string.Empty;
+
+            builder.AppendLine(string.Join(" | ", new[]
+            {
+                EscapeMarkdown(GetNodePath(node)),
+                EscapeMarkdown(node.NodeType.ToString()),
+                EscapeMarkdown(node.Status.ToString()),
+                EscapeMarkdown(detail?.LeftSize?.ToString() ?? string.Empty),
+                EscapeMarkdown(detail?.RightSize?.ToString() ?? string.Empty),
+                EscapeMarkdown(detail?.LeftModified?.ToString("u") ?? string.Empty),
+                EscapeMarkdown(detail?.RightModified?.ToString("u") ?? string.Empty),
+                EscapeMarkdown(leftHash),
+                EscapeMarkdown(rightHash),
+                EscapeMarkdown(detail?.ErrorMessage ?? string.Empty)
+            }));
+        }
+
+        await File.WriteAllTextAsync(destination, builder.ToString(), cancellationToken);
+    }
+
+    private static string GetNodePath(ComparisonNode node)
+    {
+        if (string.IsNullOrWhiteSpace(node.RelativePath))
+        {
+            return node.Name;
+        }
+
+        return node.RelativePath.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private static string? GetHash(
+        IReadOnlyDictionary<HashAlgorithmType, string>? hashes,
+        HashAlgorithmType? preferred)
+    {
+        if (hashes is null || hashes.Count == 0)
+        {
+            return null;
+        }
+
+        if (preferred is not null && hashes.TryGetValue(preferred.Value, out var value))
+        {
+            return value;
+        }
+
+        return hashes.OrderBy(pair => pair.Key.ToString(), StringComparer.OrdinalIgnoreCase)
+            .Select(pair => pair.Value)
+            .FirstOrDefault();
+    }
+
+    private static string EscapeCsv(string value)
+    {
+        if (value.Contains('"') || value.Contains(',') || value.Contains('\n'))
+        {
+            return $"\"{value.Replace("\"", "\"\"")}\"";
+        }
+
+        return value;
+    }
+
+    private static string EscapeMarkdown(string value)
+        => value
+            .Replace("|", "\\|")
+            .Replace("`", "\\`");
+}

--- a/src/ParallelCompare.App/Interactive/InteractiveFilter.cs
+++ b/src/ParallelCompare.App/Interactive/InteractiveFilter.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace ParallelCompare.App.Interactive;
+
+public enum InteractiveFilter
+{
+    All,
+    Differences,
+    LeftOnly,
+    RightOnly,
+    Errors
+}
+
+public static class InteractiveFilterExtensions
+{
+    public static InteractiveFilter Parse(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return InteractiveFilter.All;
+        }
+
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "diff" or "difference" or "differences" => InteractiveFilter.Differences,
+            "left" or "leftonly" or "left-only" => InteractiveFilter.LeftOnly,
+            "right" or "rightonly" or "right-only" => InteractiveFilter.RightOnly,
+            "error" or "errors" => InteractiveFilter.Errors,
+            _ => InteractiveFilter.All
+        };
+    }
+
+    public static string ToDisplayName(this InteractiveFilter filter)
+        => filter switch
+        {
+            InteractiveFilter.All => "All",
+            InteractiveFilter.Differences => "Differences",
+            InteractiveFilter.LeftOnly => "Left Only",
+            InteractiveFilter.RightOnly => "Right Only",
+            InteractiveFilter.Errors => "Errors",
+            _ => filter.ToString()
+        };
+}

--- a/src/ParallelCompare.App/Interactive/InteractiveTheme.cs
+++ b/src/ParallelCompare.App/Interactive/InteractiveTheme.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace ParallelCompare.App.Interactive;
+
+public sealed class InteractiveTheme
+{
+    public string Accent { get; }
+    public string Muted { get; }
+    public string Equal { get; }
+    public string Different { get; }
+    public string LeftOnly { get; }
+    public string RightOnly { get; }
+    public string Error { get; }
+
+    private InteractiveTheme(
+        string accent,
+        string muted,
+        string equal,
+        string different,
+        string leftOnly,
+        string rightOnly,
+        string error)
+    {
+        Accent = accent;
+        Muted = muted;
+        Equal = equal;
+        Different = different;
+        LeftOnly = leftOnly;
+        RightOnly = rightOnly;
+        Error = error;
+    }
+
+    public static InteractiveTheme Dark { get; } = new(
+        accent: "deepskyblue1",
+        muted: "grey58",
+        equal: "green3",
+        different: "yellow3",
+        leftOnly: "lightskyblue1",
+        rightOnly: "mediumorchid1",
+        error: "red1");
+
+    public static InteractiveTheme Light { get; } = new(
+        accent: "darkcyan",
+        muted: "grey42",
+        equal: "darkgreen",
+        different: "darkorange3",
+        leftOnly: "royalblue1",
+        rightOnly: "darkmagenta",
+        error: "red3");
+
+    public static InteractiveTheme Parse(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return Dark;
+        }
+
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "light" => Light,
+            "dark" => Dark,
+            _ => Dark
+        };
+    }
+}

--- a/src/ParallelCompare.App/Interactive/InteractiveVerbosity.cs
+++ b/src/ParallelCompare.App/Interactive/InteractiveVerbosity.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace ParallelCompare.App.Interactive;
+
+public enum InteractiveVerbosity
+{
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error
+}
+
+public static class InteractiveVerbosityExtensions
+{
+    public static InteractiveVerbosity Parse(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return InteractiveVerbosity.Info;
+        }
+
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "trace" => InteractiveVerbosity.Trace,
+            "debug" => InteractiveVerbosity.Debug,
+            "warn" or "warning" => InteractiveVerbosity.Warn,
+            "error" => InteractiveVerbosity.Error,
+            _ => InteractiveVerbosity.Info
+        };
+    }
+
+    public static InteractiveVerbosity Next(this InteractiveVerbosity verbosity)
+        => verbosity switch
+        {
+            InteractiveVerbosity.Trace => InteractiveVerbosity.Debug,
+            InteractiveVerbosity.Debug => InteractiveVerbosity.Info,
+            InteractiveVerbosity.Info => InteractiveVerbosity.Warn,
+            InteractiveVerbosity.Warn => InteractiveVerbosity.Error,
+            InteractiveVerbosity.Error => InteractiveVerbosity.Trace,
+            _ => InteractiveVerbosity.Info
+        };
+
+    public static string ToDisplayName(this InteractiveVerbosity verbosity)
+        => verbosity switch
+        {
+            InteractiveVerbosity.Trace => "Trace",
+            InteractiveVerbosity.Debug => "Debug",
+            InteractiveVerbosity.Info => "Info",
+            InteractiveVerbosity.Warn => "Warn",
+            InteractiveVerbosity.Error => "Error",
+            _ => verbosity.ToString()
+        };
+}

--- a/src/ParallelCompare.App/ParallelCompare.App.csproj
+++ b/src/ParallelCompare.App/ParallelCompare.App.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\ParallelCompare.Core\ParallelCompare.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageReference Include="Spectre.Console" Version="0.51.1" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.51.1" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/ParallelCompare.App/Program.cs
+++ b/src/ParallelCompare.App/Program.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.DependencyInjection;
+using ParallelCompare.App.Commands;
+using ParallelCompare.App.Infrastructure;
+using ParallelCompare.App.Services;
+using Spectre.Console.Cli;
+
+var services = new ServiceCollection();
+services.AddSingleton<ComparisonOrchestrator>();
+
+var registrar = new TypeRegistrar(services);
+var app = new CommandApp(registrar);
+
+app.Configure(config =>
+{
+    config.SetApplicationName("fsequal");
+    config.ValidateExamples();
+
+    config.AddCommand<CompareCommand>("compare")
+        .WithDescription("Compare two directories and report differences.");
+
+    config.AddCommand<WatchCommand>("watch")
+        .WithDescription("Continuously compare directories and refresh on changes.");
+
+    config.AddCommand<SnapshotCommand>("snapshot")
+        .WithDescription("Create a snapshot report of the current comparison.");
+
+    config.AddCommand<CompletionCommand>("completion")
+        .WithDescription("Generate shell completion scripts.");
+});
+
+return app.Run(args);

--- a/src/ParallelCompare.App/Rendering/ComparisonConsoleRenderer.cs
+++ b/src/ParallelCompare.App/Rendering/ComparisonConsoleRenderer.cs
@@ -1,0 +1,68 @@
+using System;
+using ParallelCompare.Core.Comparison;
+using Spectre.Console;
+
+namespace ParallelCompare.App.Rendering;
+
+public static class ComparisonConsoleRenderer
+{
+    public static void RenderSummary(ComparisonResult result)
+    {
+        var summary = result.Summary;
+        var table = new Table().Title("[bold]Comparison Summary[/]");
+        table.AddColumn("Metric");
+        table.AddColumn("Value");
+
+        table.AddRow("Total Files", summary.TotalFiles.ToString());
+        table.AddRow("Equal", summary.EqualFiles.ToString());
+        table.AddRow("Different", summary.DifferentFiles.ToString());
+        table.AddRow("Left Only", summary.LeftOnlyFiles.ToString());
+        table.AddRow("Right Only", summary.RightOnlyFiles.ToString());
+        table.AddRow("Errors", summary.ErrorFiles.ToString());
+
+        AnsiConsole.Write(table);
+    }
+
+    public static void RenderTree(ComparisonResult result, int maxDepth = 3)
+    {
+        var tree = new Tree(GetNodeLabel(result.Root));
+        BuildTree(tree.AddNode, result.Root, 1, maxDepth);
+        AnsiConsole.Write(tree);
+    }
+
+    private static void BuildTree(Func<string, TreeNode> addNode, ComparisonNode node, int depth, int maxDepth)
+    {
+        if (depth > maxDepth)
+        {
+            if (node.Children.Length > 0)
+            {
+                addNode("[grey]…[/]");
+            }
+
+            return;
+        }
+
+        foreach (var child in node.Children)
+        {
+            var childNode = addNode(GetNodeLabel(child));
+            BuildTree(childNode.AddNode, child, depth + 1, maxDepth);
+        }
+    }
+
+    private static string GetNodeLabel(ComparisonNode node)
+    {
+        var status = node.Status switch
+        {
+            ComparisonStatus.Equal => "[green]Equal[/]",
+            ComparisonStatus.Different => "[yellow]Different[/]",
+            ComparisonStatus.LeftOnly => "[blue]Left Only[/]",
+            ComparisonStatus.RightOnly => "[magenta]Right Only[/]",
+            ComparisonStatus.Error => "[red]Error[/]",
+            _ => node.Status.ToString()
+        };
+
+        return node.NodeType == ComparisonNodeType.Directory
+            ? $"{node.Name} ({status})"
+            : $"{node.Name} - {status}";
+    }
+}

--- a/src/ParallelCompare.App/Services/ComparisonOrchestrator.cs
+++ b/src/ParallelCompare.App/Services/ComparisonOrchestrator.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using ParallelCompare.App.Commands;
+using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.Configuration;
+using ParallelCompare.Core.Options;
+using ParallelCompare.Core.Reporting;
+
+namespace ParallelCompare.App.Services;
+
+public sealed class ComparisonOrchestrator
+{
+    private readonly ConfigurationLoader _configurationLoader = new();
+    private readonly CompareSettingsResolver _resolver = new();
+    private readonly ComparisonEngine _engine = new();
+    private readonly ComparisonResultExporter _exporter = new();
+
+    public CompareSettingsInput BuildInput(CompareCommandSettings settings)
+    {
+        var algorithms = settings.Algorithms ?? Array.Empty<string>();
+        var algorithm = algorithms.FirstOrDefault();
+        var additional = algorithms.Length > 1
+            ? algorithms.Skip(1).ToImmutableArray()
+            : ImmutableArray<string>.Empty;
+
+        return new CompareSettingsInput
+        {
+            LeftPath = settings.Left,
+            RightPath = settings.Right,
+            Mode = settings.Mode,
+            Algorithm = algorithm,
+            AdditionalAlgorithms = additional,
+            IgnorePatterns = settings.Ignore.Length > 0 ? settings.Ignore.ToImmutableArray() : ImmutableArray<string>.Empty,
+            CaseSensitive = settings.CaseSensitive ? true : null,
+            FollowSymlinks = settings.FollowSymlinks ? true : null,
+            ModifiedTimeTolerance = settings.ModifiedTimeToleranceSeconds.HasValue
+                ? TimeSpan.FromSeconds(settings.ModifiedTimeToleranceSeconds.Value)
+                : null,
+            Threads = settings.Threads,
+            BaselinePath = settings.Baseline,
+            JsonReportPath = settings.JsonReport,
+            SummaryReportPath = settings.SummaryReport,
+            ExportFormat = settings.ExportFormat,
+            NoProgress = settings.NoProgress,
+            DiffTool = settings.DiffTool,
+            Profile = settings.Profile,
+            ConfigurationPath = settings.ConfigurationPath,
+            Verbosity = settings.Verbosity,
+            FailOn = settings.FailOn,
+            Timeout = settings.TimeoutSeconds.HasValue ? TimeSpan.FromSeconds(settings.TimeoutSeconds.Value) : null,
+            EnableInteractive = settings.Interactive
+        };
+    }
+
+    public async Task<(ComparisonResult Result, ResolvedCompareSettings Resolved)> RunAsync(
+        CompareSettingsInput input,
+        CancellationToken cancellationToken)
+    {
+        var configuration = await _configurationLoader.LoadAsync(input.ConfigurationPath, cancellationToken);
+        var resolved = _resolver.Resolve(input, configuration);
+
+        var options = new ComparisonOptions
+        {
+            LeftPath = resolved.LeftPath,
+            RightPath = resolved.RightPath,
+            Mode = resolved.Mode,
+            HashAlgorithms = resolved.Algorithms,
+            IgnorePatterns = resolved.IgnorePatterns,
+            CaseSensitive = resolved.CaseSensitive,
+            FollowSymlinks = resolved.FollowSymlinks,
+            ModifiedTimeTolerance = resolved.ModifiedTimeTolerance,
+            MaxDegreeOfParallelism = resolved.Threads,
+            BaselinePath = resolved.BaselinePath,
+            EnableInteractive = input.EnableInteractive,
+            JsonReportPath = resolved.JsonReportPath,
+            SummaryReportPath = resolved.SummaryReportPath,
+            ExportFormat = resolved.ExportFormat,
+            NoProgress = resolved.NoProgress,
+            DiffTool = resolved.DiffTool,
+            CancellationToken = cancellationToken
+        };
+
+        var result = await _engine.CompareAsync(options);
+
+        if (!string.IsNullOrWhiteSpace(resolved.JsonReportPath))
+        {
+            await _exporter.WriteJsonAsync(result, resolved.JsonReportPath!, cancellationToken);
+        }
+
+        if (!string.IsNullOrWhiteSpace(resolved.SummaryReportPath))
+        {
+            await _exporter.WriteSummaryAsync(result, resolved.SummaryReportPath!, cancellationToken);
+        }
+
+        return (result, resolved);
+    }
+}

--- a/src/ParallelCompare.App/Services/ComparisonOrchestrator.cs
+++ b/src/ParallelCompare.App/Services/ComparisonOrchestrator.cs
@@ -127,7 +127,8 @@ public sealed class ComparisonOrchestrator
             ExportFormat = resolved.ExportFormat,
             NoProgress = resolved.NoProgress,
             DiffTool = resolved.DiffTool,
-            CancellationToken = cancellationToken
+            CancellationToken = cancellationToken,
+            FileSystem = resolved.FileSystem
         };
 
         return await _engine.CompareAsync(options);
@@ -160,7 +161,8 @@ public sealed class ComparisonOrchestrator
             CaseSensitive = resolved.CaseSensitive,
             ModifiedTimeTolerance = resolved.ModifiedTimeTolerance,
             Mode = resolved.Mode,
-            CancellationToken = cancellationToken
+            CancellationToken = cancellationToken,
+            FileSystem = resolved.FileSystem
         };
 
         var result = await _baselineEngine.CompareAsync(options);

--- a/src/ParallelCompare.App/Services/DiffToolLauncher.cs
+++ b/src/ParallelCompare.App/Services/DiffToolLauncher.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace ParallelCompare.App.Services;
+
+public sealed class DiffToolLauncher
+{
+    public (bool Success, string Message) TryLaunch(string? toolPath, string leftPath, string rightPath)
+    {
+        if (string.IsNullOrWhiteSpace(toolPath))
+        {
+            return (false, "No diff tool configured.");
+        }
+
+        if (!File.Exists(leftPath) || !File.Exists(rightPath))
+        {
+            return (false, "Both files must exist to launch the diff tool.");
+        }
+
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = toolPath,
+                UseShellExecute = false
+            };
+
+            startInfo.ArgumentList.Add(leftPath);
+            startInfo.ArgumentList.Add(rightPath);
+
+            var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return (false, $"Failed to launch diff tool '{toolPath}'.");
+            }
+
+            return (true, $"Launched diff tool '{toolPath}'.");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Failed to launch diff tool '{toolPath}': {ex.Message}");
+        }
+    }
+}

--- a/src/ParallelCompare.App/Services/IProcessRunner.cs
+++ b/src/ParallelCompare.App/Services/IProcessRunner.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics;
+
+namespace ParallelCompare.App.Services;
+
+public interface IProcessRunner
+{
+    Process? Start(ProcessStartInfo startInfo);
+}
+
+internal sealed class DefaultProcessRunner : IProcessRunner
+{
+    public Process? Start(ProcessStartInfo startInfo) => Process.Start(startInfo);
+}

--- a/src/ParallelCompare.Core/Baselines/BaselineComparisonEngine.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineComparisonEngine.cs
@@ -1,0 +1,512 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.FileSystemGlobbing;
+using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.Comparison.Hashing;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Baselines;
+
+public sealed class BaselineComparisonEngine
+{
+    private readonly FileHashCalculator _hashCalculator;
+
+    public BaselineComparisonEngine(FileHashCalculator? hashCalculator = null)
+    {
+        _hashCalculator = hashCalculator ?? new FileHashCalculator();
+    }
+
+    public Task<ComparisonResult> CompareAsync(BaselineComparisonOptions options)
+    {
+        return Task.Run(() => CompareInternal(options), options.CancellationToken);
+    }
+
+    private ComparisonResult CompareInternal(BaselineComparisonOptions options)
+    {
+        var cancellationToken = options.CancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var directory = new DirectoryInfo(options.LeftPath);
+        if (!directory.Exists)
+        {
+            throw new DirectoryNotFoundException($"Left directory '{options.LeftPath}' was not found.");
+        }
+
+        var manifest = options.Manifest;
+        var matcher = BuildMatcher(manifest.IgnorePatterns, manifest.CaseSensitive);
+        var root = CompareDirectory(
+            string.Empty,
+            directory.Name,
+            directory,
+            manifest.Root,
+            matcher,
+            options,
+            cancellationToken);
+
+        var summary = ComparisonSummaryCalculator.Calculate(root);
+        var metadata = new BaselineMetadata(
+            options.BaselinePath,
+            manifest.SourcePath,
+            manifest.CreatedAt,
+            manifest.Algorithms);
+
+        return new ComparisonResult(
+            Path.GetFullPath(options.LeftPath),
+            manifest.SourcePath,
+            root,
+            summary,
+            metadata);
+    }
+
+    private ComparisonNode CompareDirectory(
+        string relativePath,
+        string displayName,
+        DirectoryInfo directory,
+        BaselineEntry baseline,
+        Matcher? matcher,
+        BaselineComparisonOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var comparer = options.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+        var leftEntries = EnumerateEntries(directory, relativePath, matcher, comparer);
+        var baselineEntries = baseline.Children.ToDictionary(entry => entry.Name, comparer);
+        var names = new SortedSet<string>(comparer);
+        names.UnionWith(leftEntries.Keys);
+        names.UnionWith(baselineEntries.Keys);
+
+        var children = new List<ComparisonNode>();
+        foreach (var name in names)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            leftEntries.TryGetValue(name, out var leftInfo);
+            baselineEntries.TryGetValue(name, out var baselineEntry);
+            var childRelativePath = string.IsNullOrEmpty(relativePath)
+                ? name
+                : Path.Combine(relativePath, name);
+
+            if (leftInfo is DirectoryInfo leftDirectory)
+            {
+                if (baselineEntry?.IsDirectory == true)
+                {
+                    children.Add(CompareDirectory(
+                        childRelativePath,
+                        name,
+                        leftDirectory,
+                        baselineEntry,
+                        matcher,
+                        options,
+                        cancellationToken));
+                }
+                else if (baselineEntry is null)
+                {
+                    children.Add(BuildLeftOnlyDirectory(leftDirectory, childRelativePath, name, matcher, options, cancellationToken));
+                }
+                else
+                {
+                    children.Add(BuildTypeMismatchNode(name, childRelativePath, leftDirectory, baselineEntry));
+                }
+            }
+            else if (leftInfo is FileInfo leftFile)
+            {
+                if (baselineEntry?.IsFile == true)
+                {
+                    children.Add(CompareFile(leftFile, baselineEntry, childRelativePath, name, options, cancellationToken));
+                }
+                else if (baselineEntry is null)
+                {
+                    children.Add(BuildLeftOnlyFile(leftFile, childRelativePath, name));
+                }
+                else
+                {
+                    children.Add(BuildTypeMismatchNode(name, childRelativePath, leftFile, baselineEntry));
+                }
+            }
+            else if (baselineEntry is not null)
+            {
+                if (baselineEntry.IsDirectory)
+                {
+                    children.Add(BuildBaselineOnlyDirectory(baselineEntry, childRelativePath));
+                }
+                else
+                {
+                    children.Add(BuildBaselineOnlyFile(baselineEntry, childRelativePath));
+                }
+            }
+        }
+
+        var orderedChildren = children
+            .OrderBy(child => child.Name, comparer)
+            .ToImmutableArray();
+
+        var status = DetermineDirectoryStatus(orderedChildren);
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.Directory,
+            status,
+            null,
+            orderedChildren);
+    }
+
+    private ComparisonNode CompareFile(
+        FileInfo left,
+        BaselineEntry baseline,
+        string relativePath,
+        string displayName,
+        BaselineComparisonOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var algorithms = DetermineAlgorithms(options, baseline);
+        IReadOnlyDictionary<HashAlgorithmType, string>? leftHashes = null;
+        IReadOnlyDictionary<HashAlgorithmType, string>? baselineHashes = null;
+
+        if (!algorithms.IsDefaultOrEmpty)
+        {
+            leftHashes = _hashCalculator.ComputeHashes(left.FullName, algorithms, cancellationToken);
+            baselineHashes = algorithms.ToDictionary(
+                algorithm => algorithm,
+                algorithm => baseline.Hashes.TryGetValue(algorithm, out var value)
+                    ? value
+                    : throw new InvalidOperationException($"Baseline manifest is missing hash '{algorithm}' for '{relativePath}'."));
+        }
+
+        ComparisonStatus status;
+        if (leftHashes is not null && baselineHashes is not null)
+        {
+            status = HashesEqual(leftHashes, baselineHashes)
+                ? ComparisonStatus.Equal
+                : ComparisonStatus.Different;
+        }
+        else
+        {
+            var equal = baseline.Size.HasValue
+                && left.Length == baseline.Size.Value
+                && WithinTolerance(left.LastWriteTimeUtc, baseline.Modified, options.ModifiedTimeTolerance);
+            status = equal ? ComparisonStatus.Equal : ComparisonStatus.Different;
+        }
+
+        var detail = new FileComparisonDetail(
+            left.Length,
+            baseline.Size,
+            left.LastWriteTimeUtc,
+            baseline.Modified,
+            leftHashes,
+            baselineHashes,
+            null);
+
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.File,
+            status,
+            detail,
+            ImmutableArray<ComparisonNode>.Empty);
+    }
+
+    private static ComparisonStatus DetermineDirectoryStatus(ImmutableArray<ComparisonNode> children)
+    {
+        if (children.Length == 0)
+        {
+            return ComparisonStatus.Equal;
+        }
+
+        var hasDifferences = children.Any(child => child.Status is ComparisonStatus.Different or ComparisonStatus.LeftOnly or ComparisonStatus.RightOnly or ComparisonStatus.Error);
+        if (!hasDifferences)
+        {
+            return ComparisonStatus.Equal;
+        }
+
+        if (children.All(child => child.Status == ComparisonStatus.LeftOnly))
+        {
+            return ComparisonStatus.LeftOnly;
+        }
+
+        if (children.All(child => child.Status == ComparisonStatus.RightOnly))
+        {
+            return ComparisonStatus.RightOnly;
+        }
+
+        return ComparisonStatus.Different;
+    }
+
+    private ComparisonNode BuildLeftOnlyDirectory(
+        DirectoryInfo directory,
+        string relativePath,
+        string displayName,
+        Matcher? matcher,
+        BaselineComparisonOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var children = new List<ComparisonNode>();
+        foreach (var entry in directory.EnumerateFileSystemInfos())
+        {
+            if (ShouldIgnore(entry, relativePath, matcher))
+            {
+                continue;
+            }
+
+            var childRelative = string.IsNullOrEmpty(relativePath)
+                ? entry.Name
+                : Path.Combine(relativePath, entry.Name);
+
+            if (entry is DirectoryInfo childDirectory)
+            {
+                var child = BuildLeftOnlyDirectory(childDirectory, childRelative, entry.Name, matcher, options, cancellationToken);
+                children.Add(child);
+            }
+            else if (entry is FileInfo file)
+            {
+                children.Add(BuildLeftOnlyFile(file, childRelative, entry.Name));
+            }
+        }
+
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.Directory,
+            ComparisonStatus.LeftOnly,
+            null,
+            children.ToImmutableArray());
+    }
+
+    private ComparisonNode BuildBaselineOnlyDirectory(BaselineEntry entry, string relativePath)
+    {
+        var children = entry.Children.Select(child =>
+        {
+            var childRelative = string.IsNullOrEmpty(relativePath)
+                ? child.Name
+                : Path.Combine(relativePath, child.Name);
+
+            return child.IsDirectory
+                ? BuildBaselineOnlyDirectory(child, childRelative)
+                : BuildBaselineOnlyFile(child, childRelative);
+        }).ToImmutableArray();
+
+        return new ComparisonNode(
+            entry.Name,
+            relativePath,
+            ComparisonNodeType.Directory,
+            ComparisonStatus.RightOnly,
+            null,
+            children);
+    }
+
+    private static ComparisonNode BuildLeftOnlyFile(FileInfo file, string relativePath, string displayName)
+    {
+        var detail = new FileComparisonDetail(
+            file.Length,
+            null,
+            file.LastWriteTimeUtc,
+            null,
+            null,
+            null,
+            null);
+
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.File,
+            ComparisonStatus.LeftOnly,
+            detail,
+            ImmutableArray<ComparisonNode>.Empty);
+    }
+
+    private static ComparisonNode BuildBaselineOnlyFile(BaselineEntry entry, string relativePath)
+    {
+        var detail = new FileComparisonDetail(
+            null,
+            entry.Size,
+            null,
+            entry.Modified,
+            null,
+            entry.Hashes,
+            null);
+
+        return new ComparisonNode(
+            entry.Name,
+            relativePath,
+            ComparisonNodeType.File,
+            ComparisonStatus.RightOnly,
+            detail,
+            ImmutableArray<ComparisonNode>.Empty);
+    }
+
+    private static ComparisonNode BuildTypeMismatchNode(string displayName, string relativePath, FileSystemInfo left, BaselineEntry baseline)
+    {
+        long? leftSize = left switch
+        {
+            FileInfo lf => lf.Length,
+            DirectoryInfo _ => null,
+            _ => null
+        };
+
+        long? rightSize = baseline.Size;
+
+        DateTimeOffset? leftModified = left switch
+        {
+            FileInfo lf => lf.LastWriteTimeUtc,
+            DirectoryInfo ld => ld.LastWriteTimeUtc,
+            _ => null
+        };
+
+        var message = left is DirectoryInfo
+            ? "Left side is a directory while baseline recorded a file."
+            : "Left side is a file while baseline recorded a directory.";
+
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.File,
+            ComparisonStatus.Different,
+            new FileComparisonDetail(
+                leftSize,
+                rightSize,
+                leftModified,
+                baseline.Modified,
+                null,
+                baseline.Hashes.Count == 0 ? null : baseline.Hashes,
+                message),
+            ImmutableArray<ComparisonNode>.Empty);
+    }
+
+    private static ImmutableArray<HashAlgorithmType> DetermineAlgorithms(BaselineComparisonOptions options, BaselineEntry entry)
+    {
+        if (!options.HashAlgorithms.IsDefaultOrEmpty)
+        {
+            EnsureAlgorithmsAvailable(entry, options.HashAlgorithms);
+            return options.HashAlgorithms;
+        }
+
+        if (entry.Hashes.Count > 0)
+        {
+            return entry.Hashes.Keys.ToImmutableArray();
+        }
+
+        if (!options.Manifest.Algorithms.IsDefaultOrEmpty)
+        {
+            EnsureAlgorithmsAvailable(entry, options.Manifest.Algorithms);
+            return options.Manifest.Algorithms;
+        }
+
+        return ImmutableArray<HashAlgorithmType>.Empty;
+    }
+
+    private static void EnsureAlgorithmsAvailable(BaselineEntry entry, ImmutableArray<HashAlgorithmType> algorithms)
+    {
+        foreach (var algorithm in algorithms)
+        {
+            if (!entry.Hashes.ContainsKey(algorithm))
+            {
+                throw new InvalidOperationException($"Baseline manifest does not contain hashes for algorithm '{algorithm}'.");
+            }
+        }
+    }
+
+    private static bool HashesEqual(
+        IReadOnlyDictionary<HashAlgorithmType, string> left,
+        IReadOnlyDictionary<HashAlgorithmType, string> right)
+    {
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        foreach (var (key, leftValue) in left)
+        {
+            if (!right.TryGetValue(key, out var rightValue))
+            {
+                return false;
+            }
+
+            if (!string.Equals(leftValue, rightValue, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool WithinTolerance(DateTimeOffset? left, DateTimeOffset? right, TimeSpan? tolerance)
+    {
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        if (tolerance is null)
+        {
+            return left.Value == right.Value;
+        }
+
+        var delta = (left.Value - right.Value).Duration();
+        return delta <= tolerance.Value;
+    }
+
+    private static Dictionary<string, FileSystemInfo> EnumerateEntries(
+        DirectoryInfo directory,
+        string relativePath,
+        Matcher? matcher,
+        StringComparer comparer)
+    {
+        var result = new Dictionary<string, FileSystemInfo>(comparer);
+        if (!directory.Exists)
+        {
+            return result;
+        }
+
+        foreach (var entry in directory.EnumerateFileSystemInfos())
+        {
+            if (ShouldIgnore(entry, relativePath, matcher))
+            {
+                continue;
+            }
+
+            result[entry.Name] = entry;
+        }
+
+        return result;
+    }
+
+    private static Matcher? BuildMatcher(ImmutableArray<string> patterns, bool caseSensitive)
+    {
+        if (patterns.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        var matcher = new Matcher(caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+        matcher.AddInclude("**/*");
+        foreach (var pattern in patterns)
+        {
+            matcher.AddExclude(pattern);
+        }
+
+        return matcher;
+    }
+
+    private static bool ShouldIgnore(FileSystemInfo entry, string parentRelativePath, Matcher? matcher)
+    {
+        if (matcher is null)
+        {
+            return false;
+        }
+
+        var relativePath = string.IsNullOrEmpty(parentRelativePath)
+            ? entry.Name
+            : Path.Combine(parentRelativePath, entry.Name);
+
+        return matcher.Match(relativePath).HasMatches;
+    }
+}

--- a/src/ParallelCompare.Core/Baselines/BaselineComparisonOptions.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineComparisonOptions.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Baselines;
+
+public sealed record BaselineComparisonOptions
+{
+    public required string LeftPath { get; init; }
+    public required string BaselinePath { get; init; }
+    public required BaselineManifest Manifest { get; init; }
+    public ImmutableArray<HashAlgorithmType> HashAlgorithms { get; init; } = ImmutableArray<HashAlgorithmType>.Empty;
+    public ImmutableArray<string> IgnorePatterns { get; init; } = ImmutableArray<string>.Empty;
+    public bool CaseSensitive { get; init; }
+    public TimeSpan? ModifiedTimeTolerance { get; init; }
+    public ComparisonMode Mode { get; init; }
+    public CancellationToken CancellationToken { get; init; }
+}

--- a/src/ParallelCompare.Core/Baselines/BaselineComparisonOptions.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineComparisonOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading;
+using ParallelCompare.Core.FileSystem;
 using ParallelCompare.Core.Options;
 
 namespace ParallelCompare.Core.Baselines;
@@ -16,4 +17,5 @@ public sealed record BaselineComparisonOptions
     public TimeSpan? ModifiedTimeTolerance { get; init; }
     public ComparisonMode Mode { get; init; }
     public CancellationToken CancellationToken { get; init; }
+    public IFileSystem FileSystem { get; init; } = PhysicalFileSystem.Instance;
 }

--- a/src/ParallelCompare.Core/Baselines/BaselineEntry.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineEntry.cs
@@ -1,0 +1,24 @@
+using System.Collections.Immutable;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Baselines;
+
+public enum BaselineEntryType
+{
+    Directory,
+    File
+}
+
+public sealed record BaselineEntry(
+    string Name,
+    string RelativePath,
+    BaselineEntryType EntryType,
+    long? Size,
+    DateTimeOffset? Modified,
+    ImmutableDictionary<HashAlgorithmType, string> Hashes,
+    ImmutableArray<BaselineEntry> Children
+)
+{
+    public bool IsDirectory => EntryType == BaselineEntryType.Directory;
+    public bool IsFile => EntryType == BaselineEntryType.File;
+}

--- a/src/ParallelCompare.Core/Baselines/BaselineManifest.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineManifest.cs
@@ -1,0 +1,18 @@
+using System.Collections.Immutable;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Baselines;
+
+public sealed record BaselineManifest(
+    string Version,
+    string SourcePath,
+    DateTimeOffset CreatedAt,
+    ImmutableArray<string> IgnorePatterns,
+    bool CaseSensitive,
+    TimeSpan? ModifiedTimeTolerance,
+    ImmutableArray<HashAlgorithmType> Algorithms,
+    BaselineEntry Root
+)
+{
+    public const string CurrentVersion = "1.0";
+}

--- a/src/ParallelCompare.Core/Baselines/BaselineManifestSerializer.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineManifestSerializer.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Baselines;
+
+public sealed class BaselineManifestSerializer
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        Converters =
+        {
+            new JsonStringEnumConverter()
+        }
+    };
+
+    public async Task WriteAsync(BaselineManifest manifest, string path, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path)) ?? Directory.GetCurrentDirectory());
+        await using var stream = File.Create(path);
+        var payload = ToSerializable(manifest);
+        await JsonSerializer.SerializeAsync(stream, payload, SerializerOptions, cancellationToken);
+    }
+
+    public async Task<BaselineManifest> ReadAsync(string path, CancellationToken cancellationToken)
+    {
+        await using var stream = File.OpenRead(path);
+        var payload = await JsonSerializer.DeserializeAsync<SerializableBaselineManifest>(stream, SerializerOptions, cancellationToken)
+            ?? throw new InvalidOperationException("Baseline manifest could not be deserialized.");
+
+        return FromSerializable(payload);
+    }
+
+    private static SerializableBaselineManifest ToSerializable(BaselineManifest manifest)
+    {
+        return new SerializableBaselineManifest
+        {
+            Version = manifest.Version,
+            SourcePath = manifest.SourcePath,
+            CreatedAt = manifest.CreatedAt,
+            IgnorePatterns = manifest.IgnorePatterns.ToArray(),
+            CaseSensitive = manifest.CaseSensitive,
+            ModifiedTimeTolerance = manifest.ModifiedTimeTolerance,
+            Algorithms = manifest.Algorithms.Select(a => a.ToString()).ToArray(),
+            Root = ToSerializable(manifest.Root)
+        };
+    }
+
+    private static BaselineManifest FromSerializable(SerializableBaselineManifest manifest)
+    {
+        if (!string.Equals(manifest.Version, BaselineManifest.CurrentVersion, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Unsupported baseline manifest version '{manifest.Version}'.");
+        }
+
+        return new BaselineManifest(
+            manifest.Version,
+            manifest.SourcePath,
+            manifest.CreatedAt,
+            manifest.IgnorePatterns?.ToImmutableArray() ?? ImmutableArray<string>.Empty,
+            manifest.CaseSensitive,
+            manifest.ModifiedTimeTolerance,
+            manifest.Algorithms is null
+                ? ImmutableArray<HashAlgorithmType>.Empty
+                : manifest.Algorithms.Select(ParseAlgorithm).ToImmutableArray(),
+            FromSerializable(manifest.Root ?? throw new InvalidOperationException("Baseline manifest root is missing."))
+        );
+    }
+
+    private static SerializableBaselineEntry ToSerializable(BaselineEntry entry)
+    {
+        return new SerializableBaselineEntry
+        {
+            Name = entry.Name,
+            RelativePath = entry.RelativePath,
+            EntryType = entry.EntryType,
+            Size = entry.Size,
+            Modified = entry.Modified,
+            Hashes = entry.Hashes.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value, StringComparer.OrdinalIgnoreCase),
+            Children = entry.Children.Select(ToSerializable).ToArray()
+        };
+    }
+
+    private static BaselineEntry FromSerializable(SerializableBaselineEntry entry)
+    {
+        var hashes = entry.Hashes is null
+            ? ImmutableDictionary<HashAlgorithmType, string>.Empty
+            : entry.Hashes
+                .ToDictionary(kvp => ParseAlgorithm(kvp.Key), kvp => kvp.Value, HashAlgorithmComparer.Instance)
+                .ToImmutableDictionary(HashAlgorithmComparer.Instance);
+
+        return new BaselineEntry(
+            entry.Name ?? throw new InvalidOperationException("Baseline entry name is required."),
+            entry.RelativePath ?? string.Empty,
+            entry.EntryType,
+            entry.Size,
+            entry.Modified,
+            hashes,
+            entry.Children?.Select(FromSerializable).ToImmutableArray() ?? ImmutableArray<BaselineEntry>.Empty);
+    }
+
+    private static HashAlgorithmType ParseAlgorithm(string value)
+    {
+        return Enum.TryParse<HashAlgorithmType>(value, true, out var result)
+            ? result
+            : throw new InvalidOperationException($"Unsupported hash algorithm '{value}' in baseline manifest.");
+    }
+
+    private sealed class HashAlgorithmComparer : IEqualityComparer<HashAlgorithmType>
+    {
+        public static readonly HashAlgorithmComparer Instance = new();
+
+        public bool Equals(HashAlgorithmType x, HashAlgorithmType y) => x == y;
+
+        public int GetHashCode(HashAlgorithmType obj) => (int)obj;
+    }
+
+    private sealed record SerializableBaselineManifest
+    {
+        public string Version { get; init; } = BaselineManifest.CurrentVersion;
+        public string SourcePath { get; init; } = string.Empty;
+        public DateTimeOffset CreatedAt { get; init; }
+        public string[]? IgnorePatterns { get; init; }
+        public bool CaseSensitive { get; init; }
+        public TimeSpan? ModifiedTimeTolerance { get; init; }
+        public string[]? Algorithms { get; init; }
+        public SerializableBaselineEntry? Root { get; init; }
+    }
+
+    private sealed record SerializableBaselineEntry
+    {
+        public string? Name { get; init; }
+        public string? RelativePath { get; init; }
+        public BaselineEntryType EntryType { get; init; }
+        public long? Size { get; init; }
+        public DateTimeOffset? Modified { get; init; }
+        public Dictionary<string, string>? Hashes { get; init; }
+        public SerializableBaselineEntry[]? Children { get; init; }
+    }
+}

--- a/src/ParallelCompare.Core/Baselines/BaselineSnapshotGenerator.cs
+++ b/src/ParallelCompare.Core/Baselines/BaselineSnapshotGenerator.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.FileSystemGlobbing;
+using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.Comparison.Hashing;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Baselines;
+
+public sealed class BaselineSnapshotGenerator
+{
+    private readonly FileHashCalculator _hashCalculator;
+
+    public BaselineSnapshotGenerator(FileHashCalculator? hashCalculator = null)
+    {
+        _hashCalculator = hashCalculator ?? new FileHashCalculator();
+    }
+
+    public BaselineManifest CreateSnapshot(ResolvedCompareSettings settings, CancellationToken cancellationToken)
+    {
+        var directory = new DirectoryInfo(settings.LeftPath);
+        if (!directory.Exists)
+        {
+            throw new DirectoryNotFoundException($"Left directory '{settings.LeftPath}' was not found.");
+        }
+
+        var matcher = BuildMatcher(settings.IgnorePatterns, settings.CaseSensitive);
+        var root = BuildDirectory(directory, string.Empty, matcher, settings, cancellationToken);
+
+        return new BaselineManifest(
+            BaselineManifest.CurrentVersion,
+            Path.GetFullPath(settings.LeftPath),
+            DateTimeOffset.UtcNow,
+            settings.IgnorePatterns,
+            settings.CaseSensitive,
+            settings.ModifiedTimeTolerance,
+            settings.Algorithms,
+            root);
+    }
+
+    private BaselineEntry BuildDirectory(
+        DirectoryInfo directory,
+        string relativePath,
+        Matcher? matcher,
+        ResolvedCompareSettings settings,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var comparer = settings.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+        var children = new List<BaselineEntry>();
+
+        foreach (var entry in directory.EnumerateFileSystemInfos())
+        {
+            if (ShouldIgnore(entry, relativePath, matcher))
+            {
+                continue;
+            }
+
+            var childRelative = string.IsNullOrEmpty(relativePath)
+                ? entry.Name
+                : Path.Combine(relativePath, entry.Name);
+
+            if (entry is DirectoryInfo childDirectory)
+            {
+                var child = BuildDirectory(childDirectory, childRelative, matcher, settings, cancellationToken);
+                children.Add(child);
+            }
+            else if (entry is FileInfo file)
+            {
+                var child = BuildFileEntry(file, childRelative, settings, cancellationToken);
+                children.Add(child);
+            }
+        }
+
+        var ordered = children
+            .OrderBy(child => child.Name, comparer)
+            .ToImmutableArray();
+
+        return new BaselineEntry(
+            directory.Name,
+            relativePath,
+            BaselineEntryType.Directory,
+            null,
+            directory.LastWriteTimeUtc,
+            ImmutableDictionary<HashAlgorithmType, string>.Empty,
+            ordered);
+    }
+
+    private BaselineEntry BuildFileEntry(
+        FileInfo file,
+        string relativePath,
+        ResolvedCompareSettings settings,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var hashes = settings.Algorithms.IsDefaultOrEmpty
+            ? ImmutableDictionary<HashAlgorithmType, string>.Empty
+            : _hashCalculator
+                .ComputeHashes(file.FullName, settings.Algorithms, cancellationToken)
+                .ToImmutableDictionary(pair => pair.Key, pair => pair.Value, HashAlgorithmComparer.Instance);
+
+        return new BaselineEntry(
+            file.Name,
+            relativePath,
+            BaselineEntryType.File,
+            file.Length,
+            file.LastWriteTimeUtc,
+            hashes,
+            ImmutableArray<BaselineEntry>.Empty);
+    }
+
+    private static Matcher? BuildMatcher(ImmutableArray<string> patterns, bool caseSensitive)
+    {
+        if (patterns.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        var matcher = new Matcher(caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+        matcher.AddInclude("**/*");
+        foreach (var pattern in patterns)
+        {
+            matcher.AddExclude(pattern);
+        }
+
+        return matcher;
+    }
+
+    private static bool ShouldIgnore(FileSystemInfo entry, string parentRelativePath, Matcher? matcher)
+    {
+        if (matcher is null)
+        {
+            return false;
+        }
+
+        var relativePath = string.IsNullOrEmpty(parentRelativePath)
+            ? entry.Name
+            : Path.Combine(parentRelativePath, entry.Name);
+
+        return matcher.Match(relativePath).HasMatches;
+    }
+
+    private sealed class HashAlgorithmComparer : IEqualityComparer<HashAlgorithmType>
+    {
+        public static readonly HashAlgorithmComparer Instance = new();
+
+        public bool Equals(HashAlgorithmType x, HashAlgorithmType y) => x == y;
+
+        public int GetHashCode(HashAlgorithmType obj) => (int)obj;
+    }
+}

--- a/src/ParallelCompare.Core/Comparison/ComparisonEngine.cs
+++ b/src/ParallelCompare.Core/Comparison/ComparisonEngine.cs
@@ -53,7 +53,7 @@ public sealed class ComparisonEngine
             options,
             cancellationToken);
 
-        var summary = Summarize(root);
+        var summary = ComparisonSummaryCalculator.Calculate(root);
         return new ComparisonResult(
             Path.GetFullPath(options.LeftPath),
             Path.GetFullPath(options.RightPath),
@@ -461,44 +461,6 @@ public sealed class ComparisonEngine
         }
 
         return ComparisonStatus.Equal;
-    }
-
-    private static ComparisonSummary Summarize(ComparisonNode root)
-    {
-        var totals = (total: 0, equal: 0, different: 0, leftOnly: 0, rightOnly: 0, error: 0);
-        Traverse(root);
-        return new ComparisonSummary(totals.total, totals.equal, totals.different, totals.leftOnly, totals.rightOnly, totals.error);
-
-        void Traverse(ComparisonNode node)
-        {
-            if (node.NodeType == ComparisonNodeType.File)
-            {
-                totals.total++;
-                switch (node.Status)
-                {
-                    case ComparisonStatus.Equal:
-                        totals.equal++;
-                        break;
-                    case ComparisonStatus.Different:
-                        totals.different++;
-                        break;
-                    case ComparisonStatus.LeftOnly:
-                        totals.leftOnly++;
-                        break;
-                    case ComparisonStatus.RightOnly:
-                        totals.rightOnly++;
-                        break;
-                    case ComparisonStatus.Error:
-                        totals.error++;
-                        break;
-                }
-            }
-
-            foreach (var child in node.Children)
-            {
-                Traverse(child);
-            }
-        }
     }
 
     private static bool WithinTolerance(DateTimeOffset left, DateTimeOffset right, TimeSpan? tolerance)

--- a/src/ParallelCompare.Core/Comparison/ComparisonEngine.cs
+++ b/src/ParallelCompare.Core/Comparison/ComparisonEngine.cs
@@ -1,0 +1,699 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.FileSystemGlobbing;
+using ParallelCompare.Core.Comparison.Hashing;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Comparison;
+
+public sealed class ComparisonEngine
+{
+    private readonly FileHashCalculator _hashCalculator;
+
+    public ComparisonEngine(FileHashCalculator? hashCalculator = null)
+    {
+        _hashCalculator = hashCalculator ?? new FileHashCalculator();
+    }
+
+    public Task<ComparisonResult> CompareAsync(ComparisonOptions options)
+    {
+        return Task.Run(() => CompareInternal(options), options.CancellationToken);
+    }
+
+    private ComparisonResult CompareInternal(ComparisonOptions options)
+    {
+        var cancellationToken = options.CancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var matcher = BuildMatcher(options);
+        var leftDirectory = new DirectoryInfo(options.LeftPath);
+        var rightDirectory = new DirectoryInfo(options.RightPath);
+
+        if (!leftDirectory.Exists)
+        {
+            throw new DirectoryNotFoundException($"Left directory '{options.LeftPath}' was not found.");
+        }
+
+        if (!rightDirectory.Exists)
+        {
+            throw new DirectoryNotFoundException($"Right directory '{options.RightPath}' was not found.");
+        }
+
+        var root = CompareDirectory(
+            relativePath: string.Empty,
+            displayName: leftDirectory.Name,
+            leftDirectory,
+            rightDirectory,
+            matcher,
+            options,
+            cancellationToken);
+
+        var summary = Summarize(root);
+        return new ComparisonResult(root, summary);
+    }
+
+    private ComparisonNode CompareDirectory(
+        string relativePath,
+        string displayName,
+        DirectoryInfo left,
+        DirectoryInfo right,
+        Matcher? matcher,
+        ComparisonOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var comparer = options.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+
+        var leftEntries = EnumerateEntries(left, relativePath, matcher, comparer);
+        var rightEntries = EnumerateEntries(right, relativePath, matcher, comparer);
+
+        var names = new SortedSet<string>(comparer);
+        names.UnionWith(leftEntries.Keys);
+        names.UnionWith(rightEntries.Keys);
+
+        var workItems = names
+            .Select(name =>
+            {
+                var childRelativePath = string.IsNullOrEmpty(relativePath)
+                    ? name
+                    : Path.Combine(relativePath, name);
+
+                leftEntries.TryGetValue(name, out var leftInfo);
+                rightEntries.TryGetValue(name, out var rightInfo);
+
+                return new EntryWorkItem(name, childRelativePath, leftInfo, rightInfo);
+            })
+            .ToArray();
+
+        var parallelOptions = CreateParallelOptions(options, cancellationToken);
+        Parallel.ForEach(workItems, parallelOptions, item =>
+        {
+            item.Node = BuildNode(
+                item,
+                matcher,
+                options,
+                cancellationToken);
+        });
+
+        var orderedChildren = workItems
+            .OrderBy(item => item.Name, comparer)
+            .Select(item => item.Node ?? throw new InvalidOperationException("Comparison node was not produced for entry."))
+            .ToImmutableArray();
+
+        var status = DetermineDirectoryStatus(orderedChildren);
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.Directory,
+            status,
+            null,
+            orderedChildren);
+    }
+
+    private ComparisonNode BuildNode(
+        EntryWorkItem item,
+        Matcher? matcher,
+        ComparisonOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var leftDir = item.Left as DirectoryInfo;
+        var rightDir = item.Right as DirectoryInfo;
+
+        if (leftDir is not null && rightDir is not null)
+        {
+            return CompareDirectory(
+                item.RelativePath,
+                item.Name,
+                leftDir,
+                rightDir,
+                matcher,
+                options,
+                cancellationToken);
+        }
+
+        if (leftDir is not null && item.Right is FileInfo rightFile)
+        {
+            return BuildTypeMismatchNode(
+                item.Name,
+                item.RelativePath,
+                leftDir,
+                rightFile,
+                cancellationToken);
+        }
+
+        if (rightDir is not null && item.Left is FileInfo leftFile)
+        {
+            return BuildTypeMismatchNode(
+                item.Name,
+                item.RelativePath,
+                leftFile,
+                rightDir,
+                cancellationToken);
+        }
+
+        if (leftDir is not null)
+        {
+            return BuildSingleSideDirectory(
+                item.Name,
+                item.RelativePath,
+                leftDir,
+                ComparisonStatus.LeftOnly,
+                matcher,
+                cancellationToken);
+        }
+
+        if (rightDir is not null)
+        {
+            return BuildSingleSideDirectory(
+                item.Name,
+                item.RelativePath,
+                rightDir,
+                ComparisonStatus.RightOnly,
+                matcher,
+                cancellationToken);
+        }
+
+        return CompareFile(
+            item.RelativePath,
+            item.Name,
+            item.Left as FileInfo,
+            item.Right as FileInfo,
+            options,
+            cancellationToken);
+    }
+
+    private static ParallelOptions CreateParallelOptions(ComparisonOptions options, CancellationToken cancellationToken)
+    {
+        var maxDegree = options.MaxDegreeOfParallelism.HasValue && options.MaxDegreeOfParallelism.Value > 0
+            ? options.MaxDegreeOfParallelism.Value
+            : Environment.ProcessorCount;
+
+        return new ParallelOptions
+        {
+            MaxDegreeOfParallelism = Math.Max(1, maxDegree),
+            CancellationToken = cancellationToken
+        };
+    }
+
+    private ComparisonNode CompareFile(
+        string relativePath,
+        string displayName,
+        FileInfo? left,
+        FileInfo? right,
+        ComparisonOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (left is null && right is null)
+        {
+            throw new InvalidOperationException("Unexpected state: both file references are null.");
+        }
+
+        if (left is null)
+        {
+            return new ComparisonNode(
+                displayName,
+                relativePath,
+                ComparisonNodeType.File,
+                ComparisonStatus.RightOnly,
+                new FileComparisonDetail(
+                    null,
+                    right!.Length,
+                    null,
+                    right.LastWriteTimeUtc,
+                    null,
+                    null,
+                    null),
+                ImmutableArray<ComparisonNode>.Empty);
+        }
+
+        if (right is null)
+        {
+            return new ComparisonNode(
+                displayName,
+                relativePath,
+                ComparisonNodeType.File,
+                ComparisonStatus.LeftOnly,
+                new FileComparisonDetail(
+                    left.Length,
+                    null,
+                    left.LastWriteTimeUtc,
+                    null,
+                    null,
+                    null,
+                    null),
+                ImmutableArray<ComparisonNode>.Empty);
+        }
+
+        try
+        {
+            var status = CompareFileContents(left, right, options, cancellationToken, out var detail);
+            return new ComparisonNode(
+                displayName,
+                relativePath,
+                ComparisonNodeType.File,
+                status,
+                detail,
+                ImmutableArray<ComparisonNode>.Empty);
+        }
+        catch (Exception ex)
+        {
+            return new ComparisonNode(
+                displayName,
+                relativePath,
+                ComparisonNodeType.File,
+                ComparisonStatus.Error,
+                new FileComparisonDetail(
+                    left.Length,
+                    right.Length,
+                    left.LastWriteTimeUtc,
+                    right.LastWriteTimeUtc,
+                    null,
+                    null,
+                    ex.Message),
+                ImmutableArray<ComparisonNode>.Empty);
+        }
+    }
+
+    private ComparisonStatus CompareFileContents(
+        FileInfo left,
+        FileInfo right,
+        ComparisonOptions options,
+        CancellationToken cancellationToken,
+        out FileComparisonDetail detail)
+    {
+        IReadOnlyDictionary<HashAlgorithmType, string>? leftHashes = null;
+        IReadOnlyDictionary<HashAlgorithmType, string>? rightHashes = null;
+
+        if (options.Mode == ComparisonMode.Quick)
+        {
+            var equal = left.Length == right.Length
+                && WithinTolerance(left.LastWriteTimeUtc, right.LastWriteTimeUtc, options.ModifiedTimeTolerance);
+
+            if (!equal && options.HashAlgorithms.IsDefaultOrEmpty)
+            {
+                detail = new FileComparisonDetail(
+                    left.Length,
+                    right.Length,
+                    left.LastWriteTimeUtc,
+                    right.LastWriteTimeUtc,
+                    null,
+                    null,
+                    null);
+                return ComparisonStatus.Different;
+            }
+        }
+
+        if (options.HashAlgorithms.IsDefaultOrEmpty)
+        {
+            // Quick mode fallback: read bytes when metadata mismatch.
+            if (!FilesBinaryEqual(left.FullName, right.FullName, cancellationToken))
+            {
+                detail = new FileComparisonDetail(
+                    left.Length,
+                    right.Length,
+                    left.LastWriteTimeUtc,
+                    right.LastWriteTimeUtc,
+                    null,
+                    null,
+                    null);
+                return ComparisonStatus.Different;
+            }
+
+            detail = new FileComparisonDetail(
+                left.Length,
+                right.Length,
+                left.LastWriteTimeUtc,
+                right.LastWriteTimeUtc,
+                null,
+                null,
+                null);
+            return ComparisonStatus.Equal;
+        }
+
+        leftHashes = _hashCalculator.ComputeHashes(left.FullName, options.HashAlgorithms, cancellationToken);
+        rightHashes = _hashCalculator.ComputeHashes(right.FullName, options.HashAlgorithms, cancellationToken);
+
+        var status = HashesEqual(leftHashes, rightHashes)
+            ? ComparisonStatus.Equal
+            : ComparisonStatus.Different;
+
+        detail = new FileComparisonDetail(
+            left.Length,
+            right.Length,
+            left.LastWriteTimeUtc,
+            right.LastWriteTimeUtc,
+            leftHashes,
+            rightHashes,
+            null);
+        return status;
+    }
+
+    private static bool FilesBinaryEqual(string leftPath, string rightPath, CancellationToken cancellationToken)
+    {
+        const int BufferSize = 8192;
+        using var left = File.OpenRead(leftPath);
+        using var right = File.OpenRead(rightPath);
+
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        var leftBuffer = new byte[BufferSize];
+        var rightBuffer = new byte[BufferSize];
+
+        int leftRead;
+        while ((leftRead = left.Read(leftBuffer, 0, BufferSize)) > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var rightRead = right.Read(rightBuffer, 0, BufferSize);
+            if (leftRead != rightRead)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < leftRead; i++)
+            {
+                if (leftBuffer[i] != rightBuffer[i])
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static ComparisonStatus DetermineDirectoryStatus(IEnumerable<ComparisonNode> children)
+    {
+        var hasError = false;
+        var hasDifferent = false;
+        var hasLeftOnly = false;
+        var hasRightOnly = false;
+
+        foreach (var child in children)
+        {
+            switch (child.Status)
+            {
+                case ComparisonStatus.Error:
+                    hasError = true;
+                    break;
+                case ComparisonStatus.Different:
+                    hasDifferent = true;
+                    break;
+                case ComparisonStatus.LeftOnly:
+                    hasLeftOnly = true;
+                    break;
+                case ComparisonStatus.RightOnly:
+                    hasRightOnly = true;
+                    break;
+            }
+        }
+
+        if (hasError)
+        {
+            return ComparisonStatus.Error;
+        }
+
+        if (hasDifferent || (hasLeftOnly && hasRightOnly))
+        {
+            return ComparisonStatus.Different;
+        }
+
+        if (hasLeftOnly)
+        {
+            return ComparisonStatus.LeftOnly;
+        }
+
+        if (hasRightOnly)
+        {
+            return ComparisonStatus.RightOnly;
+        }
+
+        return ComparisonStatus.Equal;
+    }
+
+    private static ComparisonSummary Summarize(ComparisonNode root)
+    {
+        var totals = (total: 0, equal: 0, different: 0, leftOnly: 0, rightOnly: 0, error: 0);
+        Traverse(root);
+        return new ComparisonSummary(totals.total, totals.equal, totals.different, totals.leftOnly, totals.rightOnly, totals.error);
+
+        void Traverse(ComparisonNode node)
+        {
+            if (node.NodeType == ComparisonNodeType.File)
+            {
+                totals.total++;
+                switch (node.Status)
+                {
+                    case ComparisonStatus.Equal:
+                        totals.equal++;
+                        break;
+                    case ComparisonStatus.Different:
+                        totals.different++;
+                        break;
+                    case ComparisonStatus.LeftOnly:
+                        totals.leftOnly++;
+                        break;
+                    case ComparisonStatus.RightOnly:
+                        totals.rightOnly++;
+                        break;
+                    case ComparisonStatus.Error:
+                        totals.error++;
+                        break;
+                }
+            }
+
+            foreach (var child in node.Children)
+            {
+                Traverse(child);
+            }
+        }
+    }
+
+    private static bool WithinTolerance(DateTimeOffset left, DateTimeOffset right, TimeSpan? tolerance)
+    {
+        if (tolerance is null)
+        {
+            return left == right;
+        }
+
+        var delta = (left - right).Duration();
+        return delta <= tolerance.Value;
+    }
+
+    private static bool ShouldIgnore(FileSystemInfo entry, string parentRelativePath, Matcher? matcher)
+    {
+        if (matcher is null)
+        {
+            return false;
+        }
+
+        var relativePath = string.IsNullOrEmpty(parentRelativePath)
+            ? entry.Name
+            : Path.Combine(parentRelativePath, entry.Name);
+
+        return matcher.Match(relativePath).HasMatches;
+    }
+
+    private static Matcher? BuildMatcher(ComparisonOptions options)
+    {
+        if (options.IgnorePatterns.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        var matcher = new Matcher(options.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+        matcher.AddInclude("**/*");
+        foreach (var pattern in options.IgnorePatterns)
+        {
+            matcher.AddExclude(pattern);
+        }
+
+        return matcher;
+    }
+
+    private static Dictionary<string, FileSystemInfo> EnumerateEntries(
+        DirectoryInfo directory,
+        string relativePath,
+        Matcher? matcher,
+        StringComparer comparer)
+    {
+        var result = new Dictionary<string, FileSystemInfo>(comparer);
+        if (!directory.Exists)
+        {
+            return result;
+        }
+
+        foreach (var entry in directory.EnumerateFileSystemInfos())
+        {
+            if (ShouldIgnore(entry, relativePath, matcher))
+            {
+                continue;
+            }
+
+            result[entry.Name] = entry;
+        }
+
+        return result;
+    }
+
+    private ComparisonNode BuildSingleSideDirectory(
+        string displayName,
+        string relativePath,
+        DirectoryInfo directory,
+        ComparisonStatus status,
+        Matcher? matcher,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var children = new List<ComparisonNode>();
+        foreach (var entry in directory.EnumerateFileSystemInfos())
+        {
+            if (ShouldIgnore(entry, relativePath, matcher))
+            {
+                continue;
+            }
+
+            var childRelativePath = string.IsNullOrEmpty(relativePath)
+                ? entry.Name
+                : Path.Combine(relativePath, entry.Name);
+
+            if (entry is DirectoryInfo childDirectory)
+            {
+                children.Add(BuildSingleSideDirectory(
+                    entry.Name,
+                    childRelativePath,
+                    childDirectory,
+                    status,
+                    matcher,
+                    cancellationToken));
+            }
+            else if (entry is FileInfo file)
+            {
+                var detail = status == ComparisonStatus.LeftOnly
+                    ? new FileComparisonDetail(file.Length, null, file.LastWriteTimeUtc, null, null, null, null)
+                    : new FileComparisonDetail(null, file.Length, null, file.LastWriteTimeUtc, null, null, null);
+
+                children.Add(new ComparisonNode(
+                    entry.Name,
+                    childRelativePath,
+                    ComparisonNodeType.File,
+                    status,
+                    detail,
+                    ImmutableArray<ComparisonNode>.Empty));
+            }
+        }
+
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.Directory,
+            status,
+            null,
+            children.ToImmutableArray());
+    }
+
+    private ComparisonNode BuildTypeMismatchNode(
+        string displayName,
+        string relativePath,
+        FileSystemInfo left,
+        FileSystemInfo right,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        long? leftSize = left is FileInfo leftFile ? leftFile.Length : null;
+        long? rightSize = right is FileInfo rightFile ? rightFile.Length : null;
+
+        var leftModified = left switch
+        {
+            FileInfo lf => lf.LastWriteTimeUtc,
+            DirectoryInfo ld => ld.LastWriteTimeUtc,
+            _ => (DateTimeOffset?)null
+        };
+
+        var rightModified = right switch
+        {
+            FileInfo rf => rf.LastWriteTimeUtc,
+            DirectoryInfo rd => rd.LastWriteTimeUtc,
+            _ => (DateTimeOffset?)null
+        };
+
+        var message = left is DirectoryInfo
+            ? "Left side is a directory while right side is a file."
+            : "Left side is a file while right side is a directory.";
+
+        return new ComparisonNode(
+            displayName,
+            relativePath,
+            ComparisonNodeType.File,
+            ComparisonStatus.Different,
+            new FileComparisonDetail(
+                leftSize,
+                rightSize,
+                leftModified,
+                rightModified,
+                null,
+                null,
+                message),
+            ImmutableArray<ComparisonNode>.Empty);
+    }
+
+    private static bool HashesEqual(
+        IReadOnlyDictionary<HashAlgorithmType, string> left,
+        IReadOnlyDictionary<HashAlgorithmType, string> right)
+    {
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        foreach (var (key, leftValue) in left)
+        {
+            if (!right.TryGetValue(key, out var rightValue))
+            {
+                return false;
+            }
+
+            if (!string.Equals(leftValue, rightValue, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private sealed class EntryWorkItem
+    {
+        public EntryWorkItem(string name, string relativePath, FileSystemInfo? left, FileSystemInfo? right)
+        {
+            Name = name;
+            RelativePath = relativePath;
+            Left = left;
+            Right = right;
+        }
+
+        public string Name { get; }
+
+        public string RelativePath { get; }
+
+        public FileSystemInfo? Left { get; }
+
+        public FileSystemInfo? Right { get; }
+
+        public ComparisonNode? Node { get; set; }
+    }
+}

--- a/src/ParallelCompare.Core/Comparison/ComparisonNode.cs
+++ b/src/ParallelCompare.Core/Comparison/ComparisonNode.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Comparison;
+
+public enum ComparisonNodeType
+{
+    Directory,
+    File
+}
+
+public enum ComparisonStatus
+{
+    Equal,
+    Different,
+    LeftOnly,
+    RightOnly,
+    Error
+}
+
+public sealed record FileComparisonDetail(
+    long? LeftSize,
+    long? RightSize,
+    DateTimeOffset? LeftModified,
+    DateTimeOffset? RightModified,
+    IReadOnlyDictionary<HashAlgorithmType, string>? LeftHashes,
+    IReadOnlyDictionary<HashAlgorithmType, string>? RightHashes,
+    string? ErrorMessage
+);
+
+public sealed record ComparisonNode(
+    string Name,
+    string RelativePath,
+    ComparisonNodeType NodeType,
+    ComparisonStatus Status,
+    FileComparisonDetail? Detail,
+    ImmutableArray<ComparisonNode> Children
+)
+{
+    public bool HasDifferences => Status is ComparisonStatus.Different or ComparisonStatus.LeftOnly or ComparisonStatus.RightOnly or ComparisonStatus.Error;
+}
+
+public sealed record ComparisonSummary(
+    int TotalFiles,
+    int EqualFiles,
+    int DifferentFiles,
+    int LeftOnlyFiles,
+    int RightOnlyFiles,
+    int ErrorFiles
+);
+
+public sealed record ComparisonResult(
+    ComparisonNode Root,
+    ComparisonSummary Summary
+);

--- a/src/ParallelCompare.Core/Comparison/ComparisonNode.cs
+++ b/src/ParallelCompare.Core/Comparison/ComparisonNode.cs
@@ -53,5 +53,13 @@ public sealed record ComparisonResult(
     string LeftPath,
     string RightPath,
     ComparisonNode Root,
-    ComparisonSummary Summary
+    ComparisonSummary Summary,
+    BaselineMetadata? Baseline = null
+);
+
+public sealed record BaselineMetadata(
+    string ManifestPath,
+    string SourcePath,
+    DateTimeOffset CreatedAt,
+    ImmutableArray<HashAlgorithmType> Algorithms
 );

--- a/src/ParallelCompare.Core/Comparison/ComparisonNode.cs
+++ b/src/ParallelCompare.Core/Comparison/ComparisonNode.cs
@@ -50,6 +50,8 @@ public sealed record ComparisonSummary(
 );
 
 public sealed record ComparisonResult(
+    string LeftPath,
+    string RightPath,
     ComparisonNode Root,
     ComparisonSummary Summary
 );

--- a/src/ParallelCompare.Core/Comparison/ComparisonSummaryCalculator.cs
+++ b/src/ParallelCompare.Core/Comparison/ComparisonSummaryCalculator.cs
@@ -1,0 +1,44 @@
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Comparison;
+
+public static class ComparisonSummaryCalculator
+{
+    public static ComparisonSummary Calculate(ComparisonNode root)
+    {
+        var totals = (total: 0, equal: 0, different: 0, leftOnly: 0, rightOnly: 0, error: 0);
+        Traverse(root);
+        return new ComparisonSummary(totals.total, totals.equal, totals.different, totals.leftOnly, totals.rightOnly, totals.error);
+
+        void Traverse(ComparisonNode node)
+        {
+            if (node.NodeType == ComparisonNodeType.File)
+            {
+                totals.total++;
+                switch (node.Status)
+                {
+                    case ComparisonStatus.Equal:
+                        totals.equal++;
+                        break;
+                    case ComparisonStatus.Different:
+                        totals.different++;
+                        break;
+                    case ComparisonStatus.LeftOnly:
+                        totals.leftOnly++;
+                        break;
+                    case ComparisonStatus.RightOnly:
+                        totals.rightOnly++;
+                        break;
+                    case ComparisonStatus.Error:
+                        totals.error++;
+                        break;
+                }
+            }
+
+            foreach (var child in node.Children)
+            {
+                Traverse(child);
+            }
+        }
+    }
+}

--- a/src/ParallelCompare.Core/Comparison/ComparisonTreeUpdateAdapter.cs
+++ b/src/ParallelCompare.Core/Comparison/ComparisonTreeUpdateAdapter.cs
@@ -1,0 +1,289 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+namespace ParallelCompare.Core.Comparison;
+
+public sealed class ComparisonTreeUpdateAdapter : IComparisonUpdateSink
+{
+    private readonly object _sync = new();
+    private readonly Dictionary<string, MutableEntry> _entries;
+    private readonly IEqualityComparer<string> _pathComparer;
+    private readonly IComparer<string> _nameComparer;
+    private string? _rootKey;
+    private string? _pendingPath;
+
+    public ComparisonTreeUpdateAdapter(bool caseSensitive = false)
+    {
+        _pathComparer = caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+        _nameComparer = caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+        _entries = new Dictionary<string, MutableEntry>(_pathComparer);
+    }
+
+    public ComparisonTreeSnapshot? LatestSnapshot { get; private set; }
+
+    public event Action<ComparisonTreeSnapshot>? TreeUpdated;
+    public event Action<ComparisonNode>? NodeUpdated;
+
+    public void DirectoryDiscovered(string relativePath, string name)
+    {
+        lock (_sync)
+        {
+            var normalized = Normalize(relativePath);
+            var entry = GetOrCreateEntry(normalized, name, ComparisonNodeType.Directory);
+            entry.NodeType = ComparisonNodeType.Directory;
+            entry.Detail = null;
+            entry.ExplicitStatus = null;
+            AttachToParent(entry);
+            _pendingPath = normalized;
+            EmitSnapshot();
+        }
+    }
+
+    public void NodeCompleted(ComparisonNode node)
+    {
+        lock (_sync)
+        {
+            var normalized = Normalize(node.RelativePath);
+            var entry = GetOrCreateEntry(normalized, node.Name, node.NodeType);
+            entry.NodeType = node.NodeType;
+            entry.Detail = node.NodeType == ComparisonNodeType.File ? node.Detail : null;
+            entry.ExplicitStatus = node.Status;
+            entry.IsCompleted = true;
+            AttachToParent(entry);
+
+            if (node.NodeType == ComparisonNodeType.Directory)
+            {
+                foreach (var child in node.Children)
+                {
+                    var childPath = Normalize(child.RelativePath);
+                    var childEntry = GetOrCreateEntry(childPath, child.Name, child.NodeType);
+                    childEntry.NodeType = child.NodeType;
+                    if (child.NodeType == ComparisonNodeType.File)
+                    {
+                        childEntry.Detail ??= child.Detail;
+                    }
+
+                    childEntry.ExplicitStatus ??= child.Status;
+                    AttachToParent(childEntry);
+                }
+            }
+
+            _pendingPath = normalized;
+            EmitSnapshot();
+        }
+    }
+
+    private void EmitSnapshot()
+    {
+        if (_rootKey is null)
+        {
+            return;
+        }
+
+        if (!_entries.TryGetValue(_rootKey, out var rootEntry))
+        {
+            return;
+        }
+
+        var rootNode = BuildSnapshot(rootEntry);
+        var lookupBuilder = ImmutableDictionary.CreateBuilder<string, ComparisonNode>(_pathComparer);
+        PopulateLookup(rootNode, lookupBuilder);
+
+        var snapshot = new ComparisonTreeSnapshot(rootNode, lookupBuilder.ToImmutable());
+        LatestSnapshot = snapshot;
+        TreeUpdated?.Invoke(snapshot);
+
+        if (_pendingPath is { } path && snapshot.Nodes.TryGetValue(path, out var updated))
+        {
+            NodeUpdated?.Invoke(updated);
+        }
+
+        _pendingPath = null;
+    }
+
+    private ComparisonNode BuildSnapshot(MutableEntry entry)
+    {
+        var childNodes = entry.Children
+            .Select(childPath => _entries[childPath])
+            .OrderBy(child => child.Name, _nameComparer)
+            .Select(BuildSnapshot)
+            .ToImmutableArray();
+
+        var status = entry.NodeType == ComparisonNodeType.Directory
+            ? entry.ExplicitStatus ?? DetermineDirectoryStatus(childNodes)
+            : entry.ExplicitStatus ?? ComparisonStatus.Equal;
+
+        var detail = entry.NodeType == ComparisonNodeType.File ? entry.Detail : null;
+
+        return new ComparisonNode(
+            entry.Name,
+            entry.RelativePath,
+            entry.NodeType,
+            status,
+            detail,
+            childNodes);
+    }
+
+    private static ComparisonStatus DetermineDirectoryStatus(IEnumerable<ComparisonNode> children)
+    {
+        var hasError = false;
+        var hasDifferent = false;
+        var hasLeftOnly = false;
+        var hasRightOnly = false;
+
+        foreach (var child in children)
+        {
+            switch (child.Status)
+            {
+                case ComparisonStatus.Error:
+                    hasError = true;
+                    break;
+                case ComparisonStatus.Different:
+                    hasDifferent = true;
+                    break;
+                case ComparisonStatus.LeftOnly:
+                    hasLeftOnly = true;
+                    break;
+                case ComparisonStatus.RightOnly:
+                    hasRightOnly = true;
+                    break;
+            }
+        }
+
+        if (hasError)
+        {
+            return ComparisonStatus.Error;
+        }
+
+        if (hasDifferent || (hasLeftOnly && hasRightOnly))
+        {
+            return ComparisonStatus.Different;
+        }
+
+        if (hasLeftOnly)
+        {
+            return ComparisonStatus.LeftOnly;
+        }
+
+        if (hasRightOnly)
+        {
+            return ComparisonStatus.RightOnly;
+        }
+
+        return ComparisonStatus.Equal;
+    }
+
+    private void PopulateLookup(ComparisonNode node, ImmutableDictionary<string, ComparisonNode>.Builder builder)
+    {
+        builder[node.RelativePath] = node;
+        foreach (var child in node.Children)
+        {
+            PopulateLookup(child, builder);
+        }
+    }
+
+    private MutableEntry GetOrCreateEntry(string relativePath, string name, ComparisonNodeType nodeType)
+    {
+        if (_entries.TryGetValue(relativePath, out var existing))
+        {
+            if (!string.IsNullOrEmpty(name))
+            {
+                existing.Name = name;
+            }
+
+            existing.NodeType = nodeType;
+            return existing;
+        }
+
+        var entry = new MutableEntry(name, relativePath, nodeType, _pathComparer);
+        _entries[relativePath] = entry;
+        return entry;
+    }
+
+    private void AttachToParent(MutableEntry entry)
+    {
+        var parentPath = GetParent(entry.RelativePath);
+        if (parentPath is null)
+        {
+            _rootKey = entry.RelativePath;
+            return;
+        }
+
+        var parent = GetOrCreateEntry(parentPath, ExtractName(parentPath), ComparisonNodeType.Directory);
+        parent.Children.Add(entry.RelativePath);
+    }
+
+    private string ExtractName(string relativePath)
+    {
+        if (_entries.TryGetValue(relativePath, out var entry) && !string.IsNullOrEmpty(entry.Name))
+        {
+            return entry.Name;
+        }
+
+        if (string.IsNullOrEmpty(relativePath))
+        {
+            return relativePath;
+        }
+
+        var index = relativePath.LastIndexOf(Path.DirectorySeparatorChar);
+        if (index >= 0)
+        {
+            return relativePath[(index + 1)..];
+        }
+
+        return relativePath;
+    }
+
+    private static string Normalize(string relativePath)
+    {
+        if (string.IsNullOrEmpty(relativePath))
+        {
+            return string.Empty;
+        }
+
+        return relativePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+    }
+
+    private string? GetParent(string relativePath)
+    {
+        if (string.IsNullOrEmpty(relativePath))
+        {
+            return null;
+        }
+
+        var parent = Path.GetDirectoryName(relativePath);
+        if (string.IsNullOrEmpty(parent))
+        {
+            return string.Empty;
+        }
+
+        return Normalize(parent);
+    }
+
+    private sealed class MutableEntry
+    {
+        public MutableEntry(string name, string relativePath, ComparisonNodeType nodeType, IEqualityComparer<string> pathComparer)
+        {
+            Name = name;
+            RelativePath = relativePath;
+            NodeType = nodeType;
+            Children = new HashSet<string>(pathComparer);
+        }
+
+        public string Name { get; set; }
+        public string RelativePath { get; }
+        public ComparisonNodeType NodeType { get; set; }
+        public ComparisonStatus? ExplicitStatus { get; set; }
+        public FileComparisonDetail? Detail { get; set; }
+        public HashSet<string> Children { get; }
+        public bool IsCompleted { get; set; }
+    }
+}
+
+public sealed record ComparisonTreeSnapshot(
+    ComparisonNode Root,
+    ImmutableDictionary<string, ComparisonNode> Nodes
+);

--- a/src/ParallelCompare.Core/Comparison/Hashing/FileHashCalculator.cs
+++ b/src/ParallelCompare.Core/Comparison/Hashing/FileHashCalculator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Hashing;
 using System.Security.Cryptography;
+using ParallelCompare.Core.FileSystem;
 using ParallelCompare.Core.Options;
 
 namespace ParallelCompare.Core.Comparison.Hashing;
@@ -10,7 +11,7 @@ namespace ParallelCompare.Core.Comparison.Hashing;
 public sealed class FileHashCalculator
 {
     public IReadOnlyDictionary<HashAlgorithmType, string> ComputeHashes(
-        string filePath,
+        IFileEntry file,
         IEnumerable<HashAlgorithmType> algorithms,
         CancellationToken cancellationToken)
     {
@@ -19,38 +20,38 @@ public sealed class FileHashCalculator
         foreach (var algorithm in algorithms)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            result[algorithm] = ComputeHash(filePath, algorithm);
+            result[algorithm] = ComputeHash(file, algorithm);
         }
 
         return result;
     }
 
-    private string ComputeHash(string filePath, HashAlgorithmType algorithm)
+    private string ComputeHash(IFileEntry file, HashAlgorithmType algorithm)
     {
         return algorithm switch
         {
-            HashAlgorithmType.Crc32 => ComputeUsingIncremental(filePath, () => new Crc32()),
-            HashAlgorithmType.Md5 => ComputeUsingHashAlgorithm(filePath, MD5.Create),
-            HashAlgorithmType.Sha256 => ComputeUsingHashAlgorithm(filePath, SHA256.Create),
-            HashAlgorithmType.XxHash64 => ComputeUsingIncremental(filePath, () => new XxHash64()),
+            HashAlgorithmType.Crc32 => ComputeUsingIncremental(file, () => new Crc32()),
+            HashAlgorithmType.Md5 => ComputeUsingHashAlgorithm(file, MD5.Create),
+            HashAlgorithmType.Sha256 => ComputeUsingHashAlgorithm(file, SHA256.Create),
+            HashAlgorithmType.XxHash64 => ComputeUsingIncremental(file, () => new XxHash64()),
             _ => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null)
         };
     }
 
-    private static string ComputeUsingHashAlgorithm(string filePath, Func<HashAlgorithm> factory)
+    private static string ComputeUsingHashAlgorithm(IFileEntry file, Func<HashAlgorithm> factory)
     {
         using var algorithm = factory();
-        using var stream = File.OpenRead(filePath);
+        using var stream = file.OpenRead();
         var hash = algorithm.ComputeHash(stream);
         return Convert.ToHexString(hash).ToLowerInvariant();
     }
 
-    private static string ComputeUsingIncremental(string filePath, Func<NonCryptographicHashAlgorithm> factory)
+    private static string ComputeUsingIncremental(IFileEntry file, Func<NonCryptographicHashAlgorithm> factory)
     {
         var algorithm = factory();
         try
         {
-            using var stream = File.OpenRead(filePath);
+            using var stream = file.OpenRead();
             var buffer = new byte[8192];
             int read;
             while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)

--- a/src/ParallelCompare.Core/Comparison/Hashing/FileHashCalculator.cs
+++ b/src/ParallelCompare.Core/Comparison/Hashing/FileHashCalculator.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Hashing;
+using System.Security.Cryptography;
+using ParallelCompare.Core.Options;
+
+namespace ParallelCompare.Core.Comparison.Hashing;
+
+public sealed class FileHashCalculator
+{
+    public IReadOnlyDictionary<HashAlgorithmType, string> ComputeHashes(
+        string filePath,
+        IEnumerable<HashAlgorithmType> algorithms,
+        CancellationToken cancellationToken)
+    {
+        var result = new Dictionary<HashAlgorithmType, string>();
+
+        foreach (var algorithm in algorithms)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            result[algorithm] = ComputeHash(filePath, algorithm);
+        }
+
+        return result;
+    }
+
+    private string ComputeHash(string filePath, HashAlgorithmType algorithm)
+    {
+        return algorithm switch
+        {
+            HashAlgorithmType.Crc32 => ComputeUsingIncremental(filePath, () => new Crc32()),
+            HashAlgorithmType.Md5 => ComputeUsingHashAlgorithm(filePath, MD5.Create),
+            HashAlgorithmType.Sha256 => ComputeUsingHashAlgorithm(filePath, SHA256.Create),
+            HashAlgorithmType.XxHash64 => ComputeUsingIncremental(filePath, () => new XxHash64()),
+            _ => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null)
+        };
+    }
+
+    private static string ComputeUsingHashAlgorithm(string filePath, Func<HashAlgorithm> factory)
+    {
+        using var algorithm = factory();
+        using var stream = File.OpenRead(filePath);
+        var hash = algorithm.ComputeHash(stream);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static string ComputeUsingIncremental(string filePath, Func<NonCryptographicHashAlgorithm> factory)
+    {
+        var algorithm = factory();
+        try
+        {
+            using var stream = File.OpenRead(filePath);
+            var buffer = new byte[8192];
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                algorithm.Append(buffer.AsSpan(0, read));
+            }
+
+            Span<byte> destination = stackalloc byte[algorithm.HashLengthInBytes];
+            algorithm.GetCurrentHash(destination);
+            return Convert.ToHexString(destination).ToLowerInvariant();
+        }
+        finally
+        {
+            (algorithm as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/src/ParallelCompare.Core/Comparison/IComparisonUpdateSink.cs
+++ b/src/ParallelCompare.Core/Comparison/IComparisonUpdateSink.cs
@@ -1,0 +1,7 @@
+namespace ParallelCompare.Core.Comparison;
+
+public interface IComparisonUpdateSink
+{
+    void DirectoryDiscovered(string relativePath, string name);
+    void NodeCompleted(ComparisonNode node);
+}

--- a/src/ParallelCompare.Core/Configuration/ConfigurationLoader.cs
+++ b/src/ParallelCompare.Core/Configuration/ConfigurationLoader.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+
+namespace ParallelCompare.Core.Configuration;
+
+public sealed class ConfigurationLoader
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public async Task<ParallelCompareConfiguration?> LoadAsync(string? path, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Configuration file not found: {path}", path);
+        }
+
+        await using var stream = File.OpenRead(path);
+        var config = await JsonSerializer.DeserializeAsync<ParallelCompareConfiguration>(stream, Options, cancellationToken)
+            ?? new ParallelCompareConfiguration();
+
+        return config;
+    }
+}

--- a/src/ParallelCompare.Core/Configuration/ParallelCompareConfiguration.cs
+++ b/src/ParallelCompare.Core/Configuration/ParallelCompareConfiguration.cs
@@ -57,4 +57,16 @@ public class CompareProfile
 
     [JsonPropertyName("diffTool")]
     public string? DiffTool { get; init; }
+
+    [JsonPropertyName("verbosity")]
+    public string? Verbosity { get; init; }
+
+    [JsonPropertyName("interactiveTheme")]
+    public string? InteractiveTheme { get; init; }
+
+    [JsonPropertyName("interactiveFilter")]
+    public string? InteractiveFilter { get; init; }
+
+    [JsonPropertyName("interactiveVerbosity")]
+    public string? InteractiveVerbosity { get; init; }
 }

--- a/src/ParallelCompare.Core/Configuration/ParallelCompareConfiguration.cs
+++ b/src/ParallelCompare.Core/Configuration/ParallelCompareConfiguration.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Serialization;
+
+namespace ParallelCompare.Core.Configuration;
+
+public sealed record ParallelCompareConfiguration
+{
+    [JsonPropertyName("defaults")]
+    public CompareProfile Defaults { get; init; } = new();
+
+    [JsonPropertyName("profiles")]
+    public Dictionary<string, CompareProfile> Profiles { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+}
+
+public class CompareProfile
+{
+    [JsonPropertyName("left")]
+    public string? Left { get; init; }
+
+    [JsonPropertyName("right")]
+    public string? Right { get; init; }
+
+    [JsonPropertyName("mode")]
+    public string? Mode { get; init; }
+
+    [JsonPropertyName("algorithms")]
+    public string[]? Algorithms { get; init; }
+
+    [JsonPropertyName("ignore")]
+    public string[]? Ignore { get; init; }
+
+    [JsonPropertyName("caseSensitive")]
+    public bool? CaseSensitive { get; init; }
+
+    [JsonPropertyName("followSymlinks")]
+    public bool? FollowSymlinks { get; init; }
+
+    [JsonPropertyName("mtimeToleranceSeconds")]
+    public double? MTimeToleranceSeconds { get; init; }
+
+    [JsonPropertyName("threads")]
+    public int? Threads { get; init; }
+
+    [JsonPropertyName("baseline")]
+    public string? Baseline { get; init; }
+
+    [JsonPropertyName("json")]
+    public string? JsonReport { get; init; }
+
+    [JsonPropertyName("summary")]
+    public string? SummaryReport { get; init; }
+
+    [JsonPropertyName("export")]
+    public string? ExportFormat { get; init; }
+
+    [JsonPropertyName("noProgress")]
+    public bool? NoProgress { get; init; }
+
+    [JsonPropertyName("diffTool")]
+    public string? DiffTool { get; init; }
+}

--- a/src/ParallelCompare.Core/FileSystem/FileSystemEntryType.cs
+++ b/src/ParallelCompare.Core/FileSystem/FileSystemEntryType.cs
@@ -1,0 +1,7 @@
+namespace ParallelCompare.Core.FileSystem;
+
+public enum FileSystemEntryType
+{
+    Directory,
+    File
+}

--- a/src/ParallelCompare.Core/FileSystem/IDirectoryEntry.cs
+++ b/src/ParallelCompare.Core/FileSystem/IDirectoryEntry.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace ParallelCompare.Core.FileSystem;
+
+public interface IDirectoryEntry : IFileSystemEntry
+{
+    IEnumerable<IFileSystemEntry> EnumerateEntries();
+}

--- a/src/ParallelCompare.Core/FileSystem/IFileEntry.cs
+++ b/src/ParallelCompare.Core/FileSystem/IFileEntry.cs
@@ -1,0 +1,9 @@
+using System.IO;
+
+namespace ParallelCompare.Core.FileSystem;
+
+public interface IFileEntry : IFileSystemEntry
+{
+    long Length { get; }
+    Stream OpenRead();
+}

--- a/src/ParallelCompare.Core/FileSystem/IFileSystem.cs
+++ b/src/ParallelCompare.Core/FileSystem/IFileSystem.cs
@@ -1,0 +1,9 @@
+namespace ParallelCompare.Core.FileSystem;
+
+public interface IFileSystem
+{
+    IDirectoryEntry GetDirectory(string path);
+    IFileEntry GetFile(string path);
+    bool DirectoryExists(string path);
+    bool FileExists(string path);
+}

--- a/src/ParallelCompare.Core/FileSystem/IFileSystemEntry.cs
+++ b/src/ParallelCompare.Core/FileSystem/IFileSystemEntry.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ParallelCompare.Core.FileSystem;
+
+public interface IFileSystemEntry
+{
+    string Name { get; }
+    string FullPath { get; }
+    FileSystemEntryType EntryType { get; }
+    bool Exists { get; }
+    DateTimeOffset LastWriteTimeUtc { get; }
+}

--- a/src/ParallelCompare.Core/FileSystem/PhysicalFileSystem.cs
+++ b/src/ParallelCompare.Core/FileSystem/PhysicalFileSystem.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace ParallelCompare.Core.FileSystem;
+
+public sealed class PhysicalFileSystem : IFileSystem
+{
+    public static PhysicalFileSystem Instance { get; } = new();
+
+    private PhysicalFileSystem()
+    {
+    }
+
+    public IDirectoryEntry GetDirectory(string path)
+    {
+        var info = new DirectoryInfo(path);
+        return new PhysicalDirectoryEntry(info);
+    }
+
+    public IFileEntry GetFile(string path)
+    {
+        var info = new FileInfo(path);
+        return new PhysicalFileEntry(info);
+    }
+
+    public bool DirectoryExists(string path) => Directory.Exists(path);
+
+    public bool FileExists(string path) => File.Exists(path);
+
+    private sealed class PhysicalDirectoryEntry : IDirectoryEntry
+    {
+        private readonly DirectoryInfo _info;
+
+        public PhysicalDirectoryEntry(DirectoryInfo info)
+        {
+            _info = info;
+        }
+
+        public string Name => _info.Name;
+
+        public string FullPath => _info.FullName;
+
+        public FileSystemEntryType EntryType => FileSystemEntryType.Directory;
+
+        public bool Exists => _info.Exists;
+
+        public DateTimeOffset LastWriteTimeUtc => _info.LastWriteTimeUtc;
+
+        public IEnumerable<IFileSystemEntry> EnumerateEntries()
+        {
+            if (!_info.Exists)
+            {
+                yield break;
+            }
+
+            foreach (var entry in _info.EnumerateFileSystemInfos())
+            {
+                if (entry is DirectoryInfo directory)
+                {
+                    yield return new PhysicalDirectoryEntry(directory);
+                }
+                else if (entry is FileInfo file)
+                {
+                    yield return new PhysicalFileEntry(file);
+                }
+            }
+        }
+    }
+
+    private sealed class PhysicalFileEntry : IFileEntry
+    {
+        private readonly FileInfo _info;
+
+        public PhysicalFileEntry(FileInfo info)
+        {
+            _info = info;
+        }
+
+        public string Name => _info.Name;
+
+        public string FullPath => _info.FullName;
+
+        public FileSystemEntryType EntryType => FileSystemEntryType.File;
+
+        public bool Exists => _info.Exists;
+
+        public DateTimeOffset LastWriteTimeUtc => _info.LastWriteTimeUtc;
+
+        public long Length => _info.Length;
+
+        public Stream OpenRead() => _info.OpenRead();
+    }
+}

--- a/src/ParallelCompare.Core/Options/CompareSettingsInput.cs
+++ b/src/ParallelCompare.Core/Options/CompareSettingsInput.cs
@@ -26,4 +26,7 @@ public sealed record CompareSettingsInput
     public string? Verbosity { get; init; }
     public string? FailOn { get; init; }
     public TimeSpan? Timeout { get; init; }
+    public string? InteractiveTheme { get; init; }
+    public string? InteractiveFilter { get; init; }
+    public string? InteractiveVerbosity { get; init; }
 }

--- a/src/ParallelCompare.Core/Options/CompareSettingsInput.cs
+++ b/src/ParallelCompare.Core/Options/CompareSettingsInput.cs
@@ -5,7 +5,7 @@ namespace ParallelCompare.Core.Options;
 public sealed record CompareSettingsInput
 {
     public required string LeftPath { get; init; }
-    public required string RightPath { get; init; }
+    public string? RightPath { get; init; }
     public string? Mode { get; init; }
     public string? Algorithm { get; init; }
     public ImmutableArray<string> AdditionalAlgorithms { get; init; } = ImmutableArray<string>.Empty;

--- a/src/ParallelCompare.Core/Options/CompareSettingsInput.cs
+++ b/src/ParallelCompare.Core/Options/CompareSettingsInput.cs
@@ -1,0 +1,29 @@
+using System.Collections.Immutable;
+
+namespace ParallelCompare.Core.Options;
+
+public sealed record CompareSettingsInput
+{
+    public required string LeftPath { get; init; }
+    public required string RightPath { get; init; }
+    public string? Mode { get; init; }
+    public string? Algorithm { get; init; }
+    public ImmutableArray<string> AdditionalAlgorithms { get; init; } = ImmutableArray<string>.Empty;
+    public ImmutableArray<string> IgnorePatterns { get; init; } = ImmutableArray<string>.Empty;
+    public bool? CaseSensitive { get; init; }
+    public bool? FollowSymlinks { get; init; }
+    public TimeSpan? ModifiedTimeTolerance { get; init; }
+    public int? Threads { get; init; }
+    public string? BaselinePath { get; init; }
+    public bool EnableInteractive { get; init; }
+    public string? JsonReportPath { get; init; }
+    public string? SummaryReportPath { get; init; }
+    public string? ExportFormat { get; init; }
+    public bool NoProgress { get; init; }
+    public string? DiffTool { get; init; }
+    public string? Profile { get; init; }
+    public string? ConfigurationPath { get; init; }
+    public string? Verbosity { get; init; }
+    public string? FailOn { get; init; }
+    public TimeSpan? Timeout { get; init; }
+}

--- a/src/ParallelCompare.Core/Options/CompareSettingsResolver.cs
+++ b/src/ParallelCompare.Core/Options/CompareSettingsResolver.cs
@@ -55,9 +55,17 @@ public sealed class CompareSettingsResolver
             ExportFormat = input.ExportFormat ?? profile?.ExportFormat ?? defaults.ExportFormat,
             NoProgress = input.NoProgress || profile?.NoProgress == true || defaults.NoProgress == true,
             DiffTool = input.DiffTool ?? profile?.DiffTool ?? defaults.DiffTool,
-            Verbosity = input.Verbosity,
+            Verbosity = input.Verbosity ?? profile?.Verbosity ?? defaults.Verbosity,
             FailOn = input.FailOn,
-            Timeout = input.Timeout
+            Timeout = input.Timeout,
+            InteractiveTheme = input.InteractiveTheme ?? profile?.InteractiveTheme ?? defaults.InteractiveTheme,
+            InteractiveFilter = input.InteractiveFilter ?? profile?.InteractiveFilter ?? defaults.InteractiveFilter,
+            InteractiveVerbosity = input.InteractiveVerbosity
+                ?? profile?.InteractiveVerbosity
+                ?? defaults.InteractiveVerbosity
+                ?? input.Verbosity
+                ?? profile?.Verbosity
+                ?? defaults.Verbosity
         };
     }
 

--- a/src/ParallelCompare.Core/Options/CompareSettingsResolver.cs
+++ b/src/ParallelCompare.Core/Options/CompareSettingsResolver.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using ParallelCompare.Core.Configuration;
+
+namespace ParallelCompare.Core.Options;
+
+public sealed class CompareSettingsResolver
+{
+    public ResolvedCompareSettings Resolve(
+        CompareSettingsInput input,
+        ParallelCompareConfiguration? configuration)
+    {
+        var defaults = configuration?.Defaults ?? new CompareProfile();
+        CompareProfile? profile = null;
+
+        if (!string.IsNullOrWhiteSpace(input.Profile))
+        {
+            if (configuration is null)
+            {
+                throw new InvalidOperationException("A configuration file must be provided when using --profile.");
+            }
+
+            if (!configuration.Profiles.TryGetValue(input.Profile!, out profile))
+            {
+                throw new InvalidOperationException($"Profile '{input.Profile}' was not found in the configuration file.");
+            }
+        }
+
+        var left = input.LeftPath ?? profile?.Left ?? defaults.Left
+            ?? throw new InvalidOperationException("Left path must be specified either via CLI or configuration.");
+        var right = input.RightPath ?? profile?.Right ?? defaults.Right
+            ?? throw new InvalidOperationException("Right path must be specified either via CLI or configuration.");
+
+        var mode = ParseMode(input.Mode ?? profile?.Mode ?? defaults.Mode);
+        var algorithms = ResolveAlgorithms(input, profile, defaults, mode);
+        var ignore = MergeArrays(defaults.Ignore, profile?.Ignore, input.IgnorePatterns);
+
+        return new ResolvedCompareSettings
+        {
+            LeftPath = Path.GetFullPath(left),
+            RightPath = Path.GetFullPath(right),
+            Mode = mode,
+            Algorithms = algorithms,
+            IgnorePatterns = ignore,
+            CaseSensitive = input.CaseSensitive ?? profile?.CaseSensitive ?? defaults.CaseSensitive ?? false,
+            FollowSymlinks = input.FollowSymlinks ?? profile?.FollowSymlinks ?? defaults.FollowSymlinks ?? false,
+            ModifiedTimeTolerance = input.ModifiedTimeTolerance
+                ?? ToTimeSpan(profile?.MTimeToleranceSeconds)
+                ?? ToTimeSpan(defaults.MTimeToleranceSeconds),
+            Threads = input.Threads ?? profile?.Threads ?? defaults.Threads,
+            BaselinePath = input.BaselinePath ?? profile?.Baseline ?? defaults.Baseline,
+            JsonReportPath = input.JsonReportPath ?? profile?.JsonReport ?? defaults.JsonReport,
+            SummaryReportPath = input.SummaryReportPath ?? profile?.SummaryReport ?? defaults.SummaryReport,
+            ExportFormat = input.ExportFormat ?? profile?.ExportFormat ?? defaults.ExportFormat,
+            NoProgress = input.NoProgress || profile?.NoProgress == true || defaults.NoProgress == true,
+            DiffTool = input.DiffTool ?? profile?.DiffTool ?? defaults.DiffTool,
+            Verbosity = input.Verbosity,
+            FailOn = input.FailOn,
+            Timeout = input.Timeout
+        };
+    }
+
+    private static ComparisonMode ParseMode(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ComparisonMode.Quick;
+        }
+
+        return value.ToLowerInvariant() switch
+        {
+            "quick" => ComparisonMode.Quick,
+            "hash" => ComparisonMode.Hash,
+            _ => throw new InvalidOperationException($"Unsupported comparison mode '{value}'.")
+        };
+    }
+
+    private static ImmutableArray<HashAlgorithmType> ResolveAlgorithms(
+        CompareSettingsInput input,
+        CompareProfile? profile,
+        CompareProfile defaults,
+        ComparisonMode mode)
+    {
+        var builder = ImmutableArray.CreateBuilder<HashAlgorithmType>();
+        var algorithmNames = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(input.Algorithm))
+        {
+            algorithmNames.Add(input.Algorithm!);
+        }
+
+        if (!input.AdditionalAlgorithms.IsDefaultOrEmpty)
+        {
+            algorithmNames.AddRange(input.AdditionalAlgorithms);
+        }
+
+        if (algorithmNames.Count == 0)
+        {
+            if (profile?.Algorithms?.Length > 0)
+            {
+                algorithmNames.AddRange(profile.Algorithms);
+            }
+            else if (defaults.Algorithms?.Length > 0)
+            {
+                algorithmNames.AddRange(defaults.Algorithms);
+            }
+        }
+
+        if (algorithmNames.Count == 0)
+        {
+            // Default algorithm per spec: crc32 in quick mode, sha256 in hash mode.
+            algorithmNames.Add(mode == ComparisonMode.Quick ? "crc32" : "sha256");
+        }
+
+        foreach (var name in algorithmNames)
+        {
+            builder.Add(ParseAlgorithm(name));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static ImmutableArray<string> MergeArrays(
+        string[]? defaults,
+        string[]? profile,
+        ImmutableArray<string> overrides)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (defaults is { Length: > 0 })
+        {
+            foreach (var value in defaults)
+            {
+                set.Add(value);
+            }
+        }
+
+        if (profile is { Length: > 0 })
+        {
+            foreach (var value in profile)
+            {
+                set.Add(value);
+            }
+        }
+
+        if (!overrides.IsDefaultOrEmpty)
+        {
+            foreach (var value in overrides)
+            {
+                set.Add(value);
+            }
+        }
+
+        return set.ToImmutableArray();
+    }
+
+    private static TimeSpan? ToTimeSpan(double? seconds)
+        => seconds is null ? null : TimeSpan.FromSeconds(seconds.Value);
+
+    private static HashAlgorithmType ParseAlgorithm(string value)
+        => value.ToLowerInvariant() switch
+        {
+            "crc32" => HashAlgorithmType.Crc32,
+            "md5" => HashAlgorithmType.Md5,
+            "sha256" => HashAlgorithmType.Sha256,
+            "xxh64" or "xxhash64" or "xxhash" => HashAlgorithmType.XxHash64,
+            _ => throw new InvalidOperationException($"Unsupported hash algorithm '{value}'.")
+        };
+}

--- a/src/ParallelCompare.Core/Options/ComparisonMode.cs
+++ b/src/ParallelCompare.Core/Options/ComparisonMode.cs
@@ -1,0 +1,7 @@
+namespace ParallelCompare.Core.Options;
+
+public enum ComparisonMode
+{
+    Quick,
+    Hash
+}

--- a/src/ParallelCompare.Core/Options/ComparisonOptions.cs
+++ b/src/ParallelCompare.Core/Options/ComparisonOptions.cs
@@ -1,0 +1,24 @@
+using System.Collections.Immutable;
+
+namespace ParallelCompare.Core.Options;
+
+public sealed record ComparisonOptions
+{
+    public required string LeftPath { get; init; }
+    public required string RightPath { get; init; }
+    public ComparisonMode Mode { get; init; } = ComparisonMode.Quick;
+    public ImmutableArray<HashAlgorithmType> HashAlgorithms { get; init; } = ImmutableArray<HashAlgorithmType>.Empty;
+    public ImmutableArray<string> IgnorePatterns { get; init; } = ImmutableArray<string>.Empty;
+    public bool CaseSensitive { get; init; }
+    public bool FollowSymlinks { get; init; }
+    public TimeSpan? ModifiedTimeTolerance { get; init; }
+    public int? MaxDegreeOfParallelism { get; init; }
+    public string? BaselinePath { get; init; }
+    public bool EnableInteractive { get; init; }
+    public string? JsonReportPath { get; init; }
+    public string? SummaryReportPath { get; init; }
+    public string? ExportFormat { get; init; }
+    public bool NoProgress { get; init; }
+    public string? DiffTool { get; init; }
+    public CancellationToken CancellationToken { get; init; } = CancellationToken.None;
+}

--- a/src/ParallelCompare.Core/Options/ComparisonOptions.cs
+++ b/src/ParallelCompare.Core/Options/ComparisonOptions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.FileSystem;
 
 namespace ParallelCompare.Core.Options;
 
@@ -23,4 +24,5 @@ public sealed record ComparisonOptions
     public string? DiffTool { get; init; }
     public IComparisonUpdateSink? UpdateSink { get; init; }
     public CancellationToken CancellationToken { get; init; } = CancellationToken.None;
+    public IFileSystem FileSystem { get; init; } = PhysicalFileSystem.Instance;
 }

--- a/src/ParallelCompare.Core/Options/ComparisonOptions.cs
+++ b/src/ParallelCompare.Core/Options/ComparisonOptions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using ParallelCompare.Core.Comparison;
 
 namespace ParallelCompare.Core.Options;
 
@@ -20,5 +21,6 @@ public sealed record ComparisonOptions
     public string? ExportFormat { get; init; }
     public bool NoProgress { get; init; }
     public string? DiffTool { get; init; }
+    public IComparisonUpdateSink? UpdateSink { get; init; }
     public CancellationToken CancellationToken { get; init; } = CancellationToken.None;
 }

--- a/src/ParallelCompare.Core/Options/HashAlgorithmType.cs
+++ b/src/ParallelCompare.Core/Options/HashAlgorithmType.cs
@@ -1,0 +1,9 @@
+namespace ParallelCompare.Core.Options;
+
+public enum HashAlgorithmType
+{
+    Crc32,
+    Md5,
+    Sha256,
+    XxHash64
+}

--- a/src/ParallelCompare.Core/Options/ResolvedCompareSettings.cs
+++ b/src/ParallelCompare.Core/Options/ResolvedCompareSettings.cs
@@ -1,11 +1,12 @@
 using System.Collections.Immutable;
+using ParallelCompare.Core.Comparison;
 
 namespace ParallelCompare.Core.Options;
 
 public sealed record ResolvedCompareSettings
 {
     public required string LeftPath { get; init; }
-    public required string RightPath { get; init; }
+    public string? RightPath { get; init; }
     public ComparisonMode Mode { get; init; }
     public ImmutableArray<HashAlgorithmType> Algorithms { get; init; } = ImmutableArray<HashAlgorithmType>.Empty;
     public ImmutableArray<string> IgnorePatterns { get; init; } = ImmutableArray<string>.Empty;
@@ -25,4 +26,6 @@ public sealed record ResolvedCompareSettings
     public string? InteractiveTheme { get; init; }
     public string? InteractiveFilter { get; init; }
     public string? InteractiveVerbosity { get; init; }
+    public bool UsesBaseline { get; init; }
+    public BaselineMetadata? BaselineMetadata { get; init; }
 }

--- a/src/ParallelCompare.Core/Options/ResolvedCompareSettings.cs
+++ b/src/ParallelCompare.Core/Options/ResolvedCompareSettings.cs
@@ -22,4 +22,7 @@ public sealed record ResolvedCompareSettings
     public string? Verbosity { get; init; }
     public string? FailOn { get; init; }
     public TimeSpan? Timeout { get; init; }
+    public string? InteractiveTheme { get; init; }
+    public string? InteractiveFilter { get; init; }
+    public string? InteractiveVerbosity { get; init; }
 }

--- a/src/ParallelCompare.Core/Options/ResolvedCompareSettings.cs
+++ b/src/ParallelCompare.Core/Options/ResolvedCompareSettings.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.FileSystem;
 
 namespace ParallelCompare.Core.Options;
 
@@ -28,4 +29,5 @@ public sealed record ResolvedCompareSettings
     public string? InteractiveVerbosity { get; init; }
     public bool UsesBaseline { get; init; }
     public BaselineMetadata? BaselineMetadata { get; init; }
+    public IFileSystem FileSystem { get; init; } = PhysicalFileSystem.Instance;
 }

--- a/src/ParallelCompare.Core/Options/ResolvedCompareSettings.cs
+++ b/src/ParallelCompare.Core/Options/ResolvedCompareSettings.cs
@@ -1,0 +1,25 @@
+using System.Collections.Immutable;
+
+namespace ParallelCompare.Core.Options;
+
+public sealed record ResolvedCompareSettings
+{
+    public required string LeftPath { get; init; }
+    public required string RightPath { get; init; }
+    public ComparisonMode Mode { get; init; }
+    public ImmutableArray<HashAlgorithmType> Algorithms { get; init; } = ImmutableArray<HashAlgorithmType>.Empty;
+    public ImmutableArray<string> IgnorePatterns { get; init; } = ImmutableArray<string>.Empty;
+    public bool CaseSensitive { get; init; }
+    public bool FollowSymlinks { get; init; }
+    public TimeSpan? ModifiedTimeTolerance { get; init; }
+    public int? Threads { get; init; }
+    public string? BaselinePath { get; init; }
+    public string? JsonReportPath { get; init; }
+    public string? SummaryReportPath { get; init; }
+    public string? ExportFormat { get; init; }
+    public bool NoProgress { get; init; }
+    public string? DiffTool { get; init; }
+    public string? Verbosity { get; init; }
+    public string? FailOn { get; init; }
+    public TimeSpan? Timeout { get; init; }
+}

--- a/src/ParallelCompare.Core/ParallelCompare.Core.csproj
+++ b/src/ParallelCompare.Core/ParallelCompare.Core.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.9" />
+    <PackageReference Include="System.IO.Hashing" Version="9.0.9" />
+  </ItemGroup>
+
+</Project>

--- a/src/ParallelCompare.Core/Reporting/ComparisonResultExporter.cs
+++ b/src/ParallelCompare.Core/Reporting/ComparisonResultExporter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using ParallelCompare.Core.Comparison;
 
 namespace ParallelCompare.Core.Reporting;
@@ -35,7 +36,14 @@ public sealed class ComparisonResultExporter
             LeftPath = result.LeftPath,
             RightPath = result.RightPath,
             Root = ToSerializable(result.Root),
-            Summary = result.Summary
+            Summary = result.Summary,
+            Baseline = result.Baseline is null ? null : new SerializableBaselineMetadata
+            {
+                ManifestPath = result.Baseline.ManifestPath,
+                SourcePath = result.Baseline.SourcePath,
+                CreatedAt = result.Baseline.CreatedAt,
+                Algorithms = result.Baseline.Algorithms.Select(a => a.ToString()).ToArray()
+            }
         };
     }
 
@@ -67,6 +75,7 @@ public sealed class ComparisonResultExporter
         public required string RightPath { get; init; }
         public required SerializableComparisonNode Root { get; init; }
         public required ComparisonSummary Summary { get; init; }
+        public SerializableBaselineMetadata? Baseline { get; init; }
     }
 
     private sealed record SerializableComparisonNode
@@ -88,5 +97,13 @@ public sealed class ComparisonResultExporter
         public Dictionary<string, string>? LeftHashes { get; init; }
         public Dictionary<string, string>? RightHashes { get; init; }
         public string? ErrorMessage { get; init; }
+    }
+
+    private sealed record SerializableBaselineMetadata
+    {
+        public required string ManifestPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required DateTimeOffset CreatedAt { get; init; }
+        public string[]? Algorithms { get; init; }
     }
 }

--- a/src/ParallelCompare.Core/Reporting/ComparisonResultExporter.cs
+++ b/src/ParallelCompare.Core/Reporting/ComparisonResultExporter.cs
@@ -32,6 +32,8 @@ public sealed class ComparisonResultExporter
     {
         return new SerializableComparisonResult
         {
+            LeftPath = result.LeftPath,
+            RightPath = result.RightPath,
             Root = ToSerializable(result.Root),
             Summary = result.Summary
         };
@@ -61,6 +63,8 @@ public sealed class ComparisonResultExporter
 
     private sealed record SerializableComparisonResult
     {
+        public required string LeftPath { get; init; }
+        public required string RightPath { get; init; }
         public required SerializableComparisonNode Root { get; init; }
         public required ComparisonSummary Summary { get; init; }
     }

--- a/src/ParallelCompare.Core/Reporting/ComparisonResultExporter.cs
+++ b/src/ParallelCompare.Core/Reporting/ComparisonResultExporter.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using ParallelCompare.Core.Comparison;
+
+namespace ParallelCompare.Core.Reporting;
+
+public sealed class ComparisonResultExporter
+{
+    private readonly JsonSerializerOptions _options = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    public async Task WriteJsonAsync(ComparisonResult result, string path, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path)) ?? Directory.GetCurrentDirectory());
+        await using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, ToSerializable(result), _options, cancellationToken);
+    }
+
+    public async Task WriteSummaryAsync(ComparisonResult result, string path, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path)) ?? Directory.GetCurrentDirectory());
+        await using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, result.Summary, _options, cancellationToken);
+    }
+
+    private static SerializableComparisonResult ToSerializable(ComparisonResult result)
+    {
+        return new SerializableComparisonResult
+        {
+            Root = ToSerializable(result.Root),
+            Summary = result.Summary
+        };
+    }
+
+    private static SerializableComparisonNode ToSerializable(ComparisonNode node)
+    {
+        return new SerializableComparisonNode
+        {
+            Name = node.Name,
+            RelativePath = node.RelativePath,
+            NodeType = node.NodeType.ToString(),
+            Status = node.Status.ToString(),
+            Detail = node.Detail is null ? null : new SerializableFileDetail
+            {
+                LeftSize = node.Detail.LeftSize,
+                RightSize = node.Detail.RightSize,
+                LeftModified = node.Detail.LeftModified,
+                RightModified = node.Detail.RightModified,
+                LeftHashes = node.Detail.LeftHashes?.ToDictionary(x => x.Key.ToString(), x => x.Value),
+                RightHashes = node.Detail.RightHashes?.ToDictionary(x => x.Key.ToString(), x => x.Value),
+                ErrorMessage = node.Detail.ErrorMessage
+            },
+            Children = node.Children.Select(ToSerializable).ToList()
+        };
+    }
+
+    private sealed record SerializableComparisonResult
+    {
+        public required SerializableComparisonNode Root { get; init; }
+        public required ComparisonSummary Summary { get; init; }
+    }
+
+    private sealed record SerializableComparisonNode
+    {
+        public required string Name { get; init; }
+        public required string RelativePath { get; init; }
+        public required string NodeType { get; init; }
+        public required string Status { get; init; }
+        public SerializableFileDetail? Detail { get; init; }
+        public required List<SerializableComparisonNode> Children { get; init; }
+    }
+
+    private sealed record SerializableFileDetail
+    {
+        public long? LeftSize { get; init; }
+        public long? RightSize { get; init; }
+        public DateTimeOffset? LeftModified { get; init; }
+        public DateTimeOffset? RightModified { get; init; }
+        public Dictionary<string, string>? LeftHashes { get; init; }
+        public Dictionary<string, string>? RightHashes { get; init; }
+        public string? ErrorMessage { get; init; }
+    }
+}

--- a/tests/ParallelCompare.Tests/Comparison/ComparisonEngineTests.cs
+++ b/tests/ParallelCompare.Tests/Comparison/ComparisonEngineTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.Options;
+using ParallelCompare.Tests.Infrastructure;
+using Xunit;
+
+namespace ParallelCompare.Tests.Comparison;
+
+public sealed class ComparisonEngineTests
+{
+    private const string BaseDirectoryJson = """
+    {
+      "files": {
+        "file1.txt": "content of file 1",
+        "file2.txt": "content of file 2",
+        "file3.bin": { "seed": 12345, "size": 1024 },
+        "empty.txt": ""
+      },
+      "directories": {
+        "nested": {
+          "files": {
+            "deep.txt": "deep content"
+          },
+          "directories": {
+            "level2": {
+              "files": {
+                "level2.bin": { "seed": 77, "size": 2048 }
+              }
+            }
+          }
+        }
+      }
+    }
+    """;
+
+    [Fact]
+    public async Task Compare_WithIdenticalStructures_ReportsNoDifferences()
+    {
+        var options = BuildOptions(static template => template, static template => template);
+
+        var engine = new ComparisonEngine();
+        var result = await engine.CompareAsync(options);
+
+        result.Summary.DifferentFiles.Should().Be(0);
+        result.Summary.LeftOnlyFiles.Should().Be(0);
+        result.Summary.RightOnlyFiles.Should().Be(0);
+        result.Summary.ErrorFiles.Should().Be(0);
+        result.Root.Children.Should().OnlyContain(child => child.Status == ComparisonStatus.Equal);
+    }
+
+    [Fact]
+    public async Task Compare_WhenFileRemovedFromRight_IsReportedAsLeftOnly()
+    {
+        var options = BuildOptions(
+            static template => template,
+            template =>
+            {
+                var clone = template.Clone();
+                clone.RemoveEntry("file2.txt");
+                return clone;
+            });
+
+        var engine = new ComparisonEngine();
+        var result = await engine.CompareAsync(options);
+
+        result.Summary.LeftOnlyFiles.Should().Be(1);
+        result.Root.Children.Should().Contain(node => node.Name == "file2.txt" && node.Status == ComparisonStatus.LeftOnly);
+    }
+
+    [Fact]
+    public async Task Compare_WhenTextFileChanged_IsReportedAsDifferent()
+    {
+        var options = BuildOptions(
+            static template => template,
+            template =>
+            {
+                var clone = template.Clone();
+                clone.UpdateTextFile("file1.txt", "modified content");
+                return clone;
+            });
+
+        var engine = new ComparisonEngine();
+        var result = await engine.CompareAsync(options);
+
+        result.Summary.DifferentFiles.Should().Be(1);
+        result.Root.Children.Should().Contain(node => node.Name == "file1.txt" && node.Status == ComparisonStatus.Different);
+    }
+
+    [Fact]
+    public async Task Compare_WhenBinarySeedDiffers_IsReportedAsDifferent()
+    {
+        var options = BuildOptions(
+            static template => template,
+            template =>
+            {
+                var clone = template.Clone();
+                clone.UpdateBinaryFile("file3.bin", seed: 54321);
+                return clone;
+            });
+
+        var engine = new ComparisonEngine();
+        var result = await engine.CompareAsync(options);
+
+        result.Summary.DifferentFiles.Should().Be(1);
+        result.Root.Children.Should().Contain(node => node.Name == "file3.bin" && node.Status == ComparisonStatus.Different);
+    }
+
+    [Fact]
+    public async Task Compare_WhenDirectoryRemovedFromRight_IsReportedAsLeftOnly()
+    {
+        var options = BuildOptions(
+            static template => template,
+            template =>
+            {
+                var clone = template.Clone();
+                clone.RemoveEntry(Path.Combine("nested", "level2"));
+                return clone;
+            });
+
+        var engine = new ComparisonEngine();
+        var result = await engine.CompareAsync(options);
+
+        result.Summary.LeftOnlyFiles.Should().BeGreaterThan(0);
+        var nested = result.Root.Children.Single(node => node.Name == "nested");
+        nested.Status.Should().Be(ComparisonStatus.LeftOnly);
+    }
+
+    [Fact]
+    public async Task Compare_WhenFileRemovedFromLeft_IsReportedAsRightOnly()
+    {
+        var options = BuildOptions(
+            template =>
+            {
+                var clone = template.Clone();
+                clone.RemoveEntry("file2.txt");
+                return clone;
+            },
+            static template => template);
+
+        var engine = new ComparisonEngine();
+        var result = await engine.CompareAsync(options);
+
+        result.Summary.RightOnlyFiles.Should().Be(1);
+        result.Root.Children.Should().Contain(node => node.Name == "file2.txt" && node.Status == ComparisonStatus.RightOnly);
+    }
+
+    private static ComparisonOptions BuildOptions(
+        Func<DeterministicFileSystem.DeterministicFileSystemTemplate, DeterministicFileSystem.DeterministicFileSystemTemplate> leftTransformer,
+        Func<DeterministicFileSystem.DeterministicFileSystemTemplate, DeterministicFileSystem.DeterministicFileSystemTemplate> rightTransformer)
+    {
+        var baseTemplate = DeterministicFileSystem.DeterministicFileSystemTemplate.FromJson(BaseDirectoryJson);
+        var leftTemplate = leftTransformer(baseTemplate.Clone());
+        var rightTemplate = rightTransformer(baseTemplate.Clone());
+
+        var fileSystem = DeterministicFileSystem.Compose(new[]
+        {
+            (Path.Combine(Path.DirectorySeparatorChar.ToString(), "left"), leftTemplate),
+            (Path.Combine(Path.DirectorySeparatorChar.ToString(), "right"), rightTemplate)
+        }, caseSensitive: true);
+
+        return new ComparisonOptions
+        {
+            LeftPath = Path.Combine(Path.DirectorySeparatorChar.ToString(), "left"),
+            RightPath = Path.Combine(Path.DirectorySeparatorChar.ToString(), "right"),
+            Mode = ComparisonMode.Quick,
+            HashAlgorithms = ImmutableArray<HashAlgorithmType>.Empty,
+            IgnorePatterns = ImmutableArray<string>.Empty,
+            CaseSensitive = true,
+            FileSystem = fileSystem
+        };
+    }
+}

--- a/tests/ParallelCompare.Tests/Configuration/CompareSettingsResolverTests.cs
+++ b/tests/ParallelCompare.Tests/Configuration/CompareSettingsResolverTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Immutable;
+using FluentAssertions;
+using ParallelCompare.Core.Configuration;
+using ParallelCompare.Core.Options;
+using Xunit;
+
+namespace ParallelCompare.Tests.Configuration;
+
+public sealed class CompareSettingsResolverTests
+{
+    [Fact]
+    public void Resolve_WithCliOverrides_MergesAllSources()
+    {
+        var configuration = new ParallelCompareConfiguration
+        {
+            Defaults = new CompareProfile
+            {
+                Left = "defaults/left",
+                Right = "defaults/right",
+                Mode = "hash",
+                Algorithms = new[] { "sha256" },
+                Ignore = new[] { "*.tmp" },
+                Threads = 2
+            },
+            Profiles =
+            {
+                ["ci"] = new CompareProfile
+                {
+                    Right = "profile/right",
+                    Algorithms = new[] { "md5" },
+                    Ignore = new[] { "*.log" },
+                    Threads = 4
+                }
+            }
+        };
+
+        var input = new CompareSettingsInput
+        {
+            LeftPath = "cli/left",
+            RightPath = "cli/right",
+            Mode = "quick",
+            Algorithm = "crc32",
+            AdditionalAlgorithms = ImmutableArray.Create("xxhash64"),
+            IgnorePatterns = ImmutableArray.Create("build/*"),
+            Threads = 8,
+            Profile = "ci"
+        };
+
+        var resolver = new CompareSettingsResolver();
+        var resolved = resolver.Resolve(input, configuration);
+
+        resolved.LeftPath.Should().EndWith("cli/left");
+        resolved.RightPath.Should().EndWith("cli/right");
+        resolved.Mode.Should().Be(ComparisonMode.Quick);
+        resolved.Algorithms.Should().Contain(new[] { HashAlgorithmType.Crc32, HashAlgorithmType.XxHash64 });
+        resolved.IgnorePatterns.Should().BeEquivalentTo(new[] { "*.tmp", "*.log", "build/*" });
+        resolved.Threads.Should().Be(8);
+    }
+
+    [Fact]
+    public void Resolve_WithoutRightOrBaseline_Throws()
+    {
+        var configuration = new ParallelCompareConfiguration();
+        var input = new CompareSettingsInput
+        {
+            LeftPath = "left"
+        };
+
+        var resolver = new CompareSettingsResolver();
+        Action act = () => resolver.Resolve(input, configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Right path must be specified either via CLI or configuration unless a baseline manifest is provided.*");
+    }
+
+    [Fact]
+    public void Resolve_WithMissingProfile_Throws()
+    {
+        var configuration = new ParallelCompareConfiguration();
+        var input = new CompareSettingsInput
+        {
+            LeftPath = "left",
+            RightPath = "right",
+            Profile = "missing"
+        };
+
+        var resolver = new CompareSettingsResolver();
+        Action act = () => resolver.Resolve(input, configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Profile 'missing' was not found in the configuration file.");
+    }
+}

--- a/tests/ParallelCompare.Tests/Infrastructure/DeterministicFileSystem.cs
+++ b/tests/ParallelCompare.Tests/Infrastructure/DeterministicFileSystem.cs
@@ -1,0 +1,592 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using ParallelCompare.Core.FileSystem;
+
+namespace ParallelCompare.Tests.Infrastructure;
+
+internal sealed class DeterministicFileSystem : IFileSystem
+{
+    private readonly string _rootPath;
+    private readonly Dictionary<string, DirectoryNode> _directories;
+    private readonly Dictionary<string, FileNode> _files;
+    private readonly bool _caseSensitive;
+
+    private DeterministicFileSystem(string rootPath, DirectoryNode root, bool caseSensitive)
+    {
+        _rootPath = NormalizeDirectory(rootPath);
+        _caseSensitive = caseSensitive;
+        _directories = new Dictionary<string, DirectoryNode>(CreateComparer(caseSensitive))
+        {
+            [_rootPath] = root
+        };
+        _files = new Dictionary<string, FileNode>(CreateComparer(caseSensitive));
+        IndexNodes(_rootPath, root);
+    }
+
+    public static DeterministicFileSystem FromTemplate(string rootPath, DeterministicFileSystemTemplate template, bool caseSensitive)
+        => new(rootPath, template.Build(caseSensitive, Path.GetFileName(NormalizeDirectory(rootPath))), caseSensitive);
+
+    public static DeterministicFileSystem Compose(IEnumerable<(string Path, DeterministicFileSystemTemplate Template)> mounts, bool caseSensitive)
+    {
+        var comparer = CreateComparer(caseSensitive);
+        var root = new DirectoryNode("root", DateTimeOffset.UnixEpoch, comparer);
+
+        foreach (var (path, template) in mounts)
+        {
+            var normalized = NormalizeDirectory(path);
+            var segments = normalized.TrimStart(Path.DirectorySeparatorChar)
+                .Split(new[] { Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
+
+            if (segments.Length == 0)
+            {
+                root = template.Build(caseSensitive, "root");
+                continue;
+            }
+
+            var current = root;
+            for (var i = 0; i < segments.Length - 1; i++)
+            {
+                var segment = segments[i];
+                if (!current.Directories.TryGetValue(segment, out var next))
+                {
+                    next = new DirectoryNode(segment, DateTimeOffset.UnixEpoch, comparer);
+                    current.Directories[segment] = next;
+                }
+
+                current = next;
+            }
+
+            var leafName = segments[^1];
+            current.Directories[leafName] = template.Build(caseSensitive, leafName);
+        }
+
+        return new DeterministicFileSystem(Path.DirectorySeparatorChar.ToString(), root, caseSensitive);
+    }
+
+    public IDirectoryEntry GetDirectory(string path)
+    {
+        var normalized = NormalizeDirectory(path);
+        if (_directories.TryGetValue(normalized, out var node))
+        {
+            return new DirectoryEntry(node, normalized, this);
+        }
+
+        return new MissingDirectoryEntry(Path.GetFileName(normalized), normalized);
+    }
+
+    public IFileEntry GetFile(string path)
+    {
+        var normalized = NormalizeFile(path);
+        if (_files.TryGetValue(normalized, out var node))
+        {
+            return new FileEntry(node, normalized);
+        }
+
+        return new MissingFileEntry(Path.GetFileName(normalized), normalized);
+    }
+
+    public bool DirectoryExists(string path) => _directories.ContainsKey(NormalizeDirectory(path));
+
+    public bool FileExists(string path) => _files.ContainsKey(NormalizeFile(path));
+
+    private void IndexNodes(string currentPath, DirectoryNode node)
+    {
+        foreach (var (name, directory) in node.Directories)
+        {
+            var childPath = NormalizeDirectory(Path.Combine(currentPath, name));
+            _directories[childPath] = directory;
+            IndexNodes(childPath, directory);
+        }
+
+        foreach (var (name, file) in node.Files)
+        {
+            var filePath = NormalizeFile(Path.Combine(currentPath, name));
+            _files[filePath] = file;
+        }
+    }
+
+    private static string NormalizeDirectory(string path)
+    {
+        var full = Path.GetFullPath(path);
+        if (full.Length > 1 && full.EndsWith(Path.DirectorySeparatorChar))
+        {
+            full = full.TrimEnd(Path.DirectorySeparatorChar);
+        }
+
+        return full;
+    }
+
+    private static string NormalizeFile(string path) => Path.GetFullPath(path);
+
+    private static StringComparer CreateComparer(bool caseSensitive)
+        => caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+
+    private sealed class DirectoryEntry : IDirectoryEntry
+    {
+        private readonly DirectoryNode _node;
+        private readonly string _path;
+        private readonly DeterministicFileSystem _fileSystem;
+
+        public DirectoryEntry(DirectoryNode node, string path, DeterministicFileSystem fileSystem)
+        {
+            _node = node;
+            _path = path;
+            _fileSystem = fileSystem;
+        }
+
+        public string Name => _node.Name;
+
+        public string FullPath => _path;
+
+        public FileSystemEntryType EntryType => FileSystemEntryType.Directory;
+
+        public bool Exists => true;
+
+        public DateTimeOffset LastWriteTimeUtc => _node.LastWriteTimeUtc;
+
+        public IEnumerable<IFileSystemEntry> EnumerateEntries()
+        {
+            foreach (var directory in _node.Directories.Values)
+            {
+                var childPath = NormalizeDirectory(Path.Combine(_path, directory.Name));
+                yield return new DirectoryEntry(directory, childPath, _fileSystem);
+            }
+
+            foreach (var file in _node.Files.Values)
+            {
+                var childPath = NormalizeFile(Path.Combine(_path, file.Name));
+                yield return new FileEntry(file, childPath);
+            }
+        }
+    }
+
+    private sealed class FileEntry : IFileEntry
+    {
+        private readonly FileNode _node;
+        private readonly string _path;
+
+        public FileEntry(FileNode node, string path)
+        {
+            _node = node;
+            _path = path;
+        }
+
+        public string Name => _node.Name;
+
+        public string FullPath => _path;
+
+        public FileSystemEntryType EntryType => FileSystemEntryType.File;
+
+        public bool Exists => true;
+
+        public DateTimeOffset LastWriteTimeUtc => _node.LastWriteTimeUtc;
+
+        public long Length => _node.Length;
+
+        public Stream OpenRead() => _node.OpenRead();
+    }
+
+    private sealed class MissingDirectoryEntry : IDirectoryEntry
+    {
+        public MissingDirectoryEntry(string name, string path)
+        {
+            Name = string.IsNullOrEmpty(name) ? path : name;
+            FullPath = path;
+        }
+
+        public string Name { get; }
+
+        public string FullPath { get; }
+
+        public FileSystemEntryType EntryType => FileSystemEntryType.Directory;
+
+        public bool Exists => false;
+
+        public DateTimeOffset LastWriteTimeUtc => DateTimeOffset.MinValue;
+
+        public IEnumerable<IFileSystemEntry> EnumerateEntries()
+        {
+            yield break;
+        }
+    }
+
+    private sealed class MissingFileEntry : IFileEntry
+    {
+        public MissingFileEntry(string name, string path)
+        {
+            Name = string.IsNullOrEmpty(name) ? path : name;
+            FullPath = path;
+        }
+
+        public string Name { get; }
+
+        public string FullPath { get; }
+
+        public FileSystemEntryType EntryType => FileSystemEntryType.File;
+
+        public bool Exists => false;
+
+        public DateTimeOffset LastWriteTimeUtc => DateTimeOffset.MinValue;
+
+        public long Length => 0;
+
+        public Stream OpenRead() => Stream.Null;
+    }
+
+    internal sealed class DirectoryNode
+    {
+        public DirectoryNode(string name, DateTimeOffset lastWriteTimeUtc, StringComparer comparer)
+        {
+            Name = name;
+            LastWriteTimeUtc = lastWriteTimeUtc;
+            Directories = new Dictionary<string, DirectoryNode>(comparer);
+            Files = new Dictionary<string, FileNode>(comparer);
+        }
+
+        public string Name { get; }
+
+        public DateTimeOffset LastWriteTimeUtc { get; }
+
+        public Dictionary<string, DirectoryNode> Directories { get; }
+
+        public Dictionary<string, FileNode> Files { get; }
+    }
+
+    internal abstract class FileNode
+    {
+        protected FileNode(string name, DateTimeOffset lastWriteTimeUtc)
+        {
+            Name = name;
+            LastWriteTimeUtc = lastWriteTimeUtc;
+        }
+
+        public string Name { get; }
+
+        public DateTimeOffset LastWriteTimeUtc { get; }
+
+        public abstract long Length { get; }
+
+        public abstract Stream OpenRead();
+    }
+
+    internal sealed class TextFileNode : FileNode
+    {
+        private readonly byte[] _data;
+
+        public TextFileNode(string name, DateTimeOffset lastWriteTimeUtc, string content)
+            : base(name, lastWriteTimeUtc)
+        {
+            _data = Encoding.UTF8.GetBytes(content ?? string.Empty);
+        }
+
+        public override long Length => _data.LongLength;
+
+        public override Stream OpenRead() => new MemoryStream(_data, writable: false);
+    }
+
+    internal sealed class BinaryFileNode : FileNode
+    {
+        private readonly int _seed;
+        private readonly int _size;
+
+        public BinaryFileNode(string name, DateTimeOffset lastWriteTimeUtc, int seed, int size)
+            : base(name, lastWriteTimeUtc)
+        {
+            _seed = seed;
+            _size = size;
+        }
+
+        public override long Length => _size;
+
+        public override Stream OpenRead()
+        {
+            var data = new byte[_size];
+            var random = new Random(_seed);
+            random.NextBytes(data);
+            return new MemoryStream(data, writable: false);
+        }
+    }
+
+    public sealed class DeterministicFileSystemTemplate
+    {
+        private readonly DirectoryDefinition _root;
+
+        private DeterministicFileSystemTemplate(DirectoryDefinition root)
+        {
+            _root = root;
+        }
+
+        public static DeterministicFileSystemTemplate FromJson(string json)
+        {
+            using var document = JsonDocument.Parse(json);
+            var root = ParseDirectory(document.RootElement, "root");
+            return new DeterministicFileSystemTemplate(root);
+        }
+
+        public DeterministicFileSystemTemplate Clone()
+            => new(new DirectoryDefinition(_root));
+
+        public void RemoveEntry(string relativePath)
+        {
+            var segments = Split(relativePath);
+            RemoveEntry(_root, segments, 0);
+        }
+
+        public void UpdateTextFile(string relativePath, string content)
+        {
+            var file = GetFileDefinition(relativePath);
+            if (file is TextFileDefinition text)
+            {
+                text.Content = content;
+                return;
+            }
+
+            throw new InvalidOperationException($"File '{relativePath}' is not a text file.");
+        }
+
+        public void UpdateBinaryFile(string relativePath, int? seed = null, int? size = null)
+        {
+            var file = GetFileDefinition(relativePath);
+            if (file is BinaryFileDefinition binary)
+            {
+                if (seed.HasValue)
+                {
+                    binary.Seed = seed.Value;
+                }
+
+                if (size.HasValue)
+                {
+                    binary.Size = size.Value;
+                }
+
+                return;
+            }
+
+            throw new InvalidOperationException($"File '{relativePath}' is not a binary file.");
+        }
+
+        public DeterministicFileSystem BuildFileSystem(string rootPath, bool caseSensitive)
+            => DeterministicFileSystem.FromTemplate(rootPath, this, caseSensitive);
+
+        internal DirectoryNode Build(bool caseSensitive, string? overrideName = null)
+        {
+            var comparer = CreateComparer(caseSensitive);
+            return BuildDirectory(_root, comparer, overrideName ?? _root.Name);
+        }
+
+        private static DirectoryNode BuildDirectory(DirectoryDefinition definition, StringComparer comparer, string? overrideName = null)
+        {
+            var node = new DirectoryNode(overrideName ?? definition.Name, definition.LastWriteTimeUtc, comparer);
+            foreach (var (name, directory) in definition.Directories)
+            {
+                node.Directories[name] = BuildDirectory(directory, comparer);
+            }
+
+            foreach (var (name, file) in definition.Files)
+            {
+                node.Files[name] = file.ToNode(name);
+            }
+
+            return node;
+        }
+
+        private static DirectoryDefinition ParseDirectory(JsonElement element, string name)
+        {
+            var modified = element.TryGetProperty("modified", out var modifiedElement)
+                ? modifiedElement.GetDateTimeOffset()
+                : DateTimeOffset.UnixEpoch;
+
+            var directory = new DirectoryDefinition(name, modified);
+
+            if (element.TryGetProperty("directories", out var directoriesElement))
+            {
+                foreach (var child in directoriesElement.EnumerateObject())
+                {
+                    directory.Directories[child.Name] = ParseDirectory(child.Value, child.Name);
+                }
+            }
+
+            if (element.TryGetProperty("files", out var filesElement))
+            {
+                foreach (var child in filesElement.EnumerateObject())
+                {
+                    directory.Files[child.Name] = ParseFile(child.Value);
+                }
+            }
+
+            return directory;
+        }
+
+        private static FileDefinition ParseFile(JsonElement element)
+        {
+            if (element.ValueKind == JsonValueKind.String)
+            {
+                return new TextFileDefinition(element.GetString() ?? string.Empty, DateTimeOffset.UnixEpoch);
+            }
+
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidOperationException("Unsupported file definition.");
+            }
+
+            var modified = element.TryGetProperty("modified", out var modifiedElement)
+                ? modifiedElement.GetDateTimeOffset()
+                : DateTimeOffset.UnixEpoch;
+
+            if (element.TryGetProperty("content", out var contentElement))
+            {
+                return new TextFileDefinition(contentElement.GetString() ?? string.Empty, modified);
+            }
+
+            var seed = element.GetProperty("seed").GetInt32();
+            var size = element.GetProperty("size").GetInt32();
+            return new BinaryFileDefinition(seed, size, modified);
+        }
+
+        private static void RemoveEntry(DirectoryDefinition directory, IReadOnlyList<string> segments, int index)
+        {
+            if (index >= segments.Count)
+            {
+                return;
+            }
+
+            var key = segments[index];
+
+            if (index == segments.Count - 1)
+            {
+                directory.Files.Remove(key);
+                directory.Directories.Remove(key);
+                return;
+            }
+
+            if (directory.Directories.TryGetValue(key, out var child))
+            {
+                RemoveEntry(child, segments, index + 1);
+            }
+        }
+
+        private FileDefinition GetFileDefinition(string relativePath)
+        {
+            var segments = Split(relativePath);
+            var directory = _root;
+            for (var i = 0; i < segments.Count - 1; i++)
+            {
+                if (!directory.Directories.TryGetValue(segments[i], out var next))
+                {
+                    throw new InvalidOperationException($"Directory '{relativePath}' does not exist.");
+                }
+
+                directory = next;
+            }
+
+            var fileName = segments[^1];
+            if (!directory.Files.TryGetValue(fileName, out var file))
+            {
+                throw new InvalidOperationException($"File '{relativePath}' does not exist.");
+            }
+
+            return file;
+        }
+
+        private static List<string> Split(string relativePath)
+        {
+            var segments = relativePath
+                .Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries)
+                .ToList();
+
+            if (segments.Count == 0)
+            {
+                throw new InvalidOperationException("Relative path must contain at least one segment.");
+            }
+
+            return segments;
+        }
+
+        private sealed class DirectoryDefinition
+        {
+            public DirectoryDefinition(string name, DateTimeOffset lastWriteTimeUtc)
+            {
+                Name = name;
+                LastWriteTimeUtc = lastWriteTimeUtc;
+                Directories = new Dictionary<string, DirectoryDefinition>(StringComparer.OrdinalIgnoreCase);
+                Files = new Dictionary<string, FileDefinition>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            public DirectoryDefinition(DirectoryDefinition other)
+            {
+                Name = other.Name;
+                LastWriteTimeUtc = other.LastWriteTimeUtc;
+                Directories = new Dictionary<string, DirectoryDefinition>(other.Directories.Count, StringComparer.OrdinalIgnoreCase);
+                foreach (var (key, value) in other.Directories)
+                {
+                    Directories[key] = new DirectoryDefinition(value);
+                }
+
+                Files = new Dictionary<string, FileDefinition>(other.Files.Count, StringComparer.OrdinalIgnoreCase);
+                foreach (var (key, value) in other.Files)
+                {
+                    Files[key] = value.Clone();
+                }
+            }
+
+            public string Name { get; }
+
+            public DateTimeOffset LastWriteTimeUtc { get; }
+
+            public Dictionary<string, DirectoryDefinition> Directories { get; }
+
+            public Dictionary<string, FileDefinition> Files { get; }
+        }
+
+        private abstract class FileDefinition
+        {
+            protected FileDefinition(DateTimeOffset lastWriteTimeUtc)
+            {
+                LastWriteTimeUtc = lastWriteTimeUtc;
+            }
+
+            public DateTimeOffset LastWriteTimeUtc { get; protected set; }
+
+            public abstract FileNode ToNode(string name);
+
+            public abstract FileDefinition Clone();
+        }
+
+        private sealed class TextFileDefinition : FileDefinition
+        {
+            public TextFileDefinition(string content, DateTimeOffset modified)
+                : base(modified)
+            {
+                Content = content;
+            }
+
+            public string Content { get; set; }
+
+            public override FileNode ToNode(string name) => new TextFileNode(name, LastWriteTimeUtc, Content);
+
+            public override FileDefinition Clone() => new TextFileDefinition(Content, LastWriteTimeUtc);
+        }
+
+        private sealed class BinaryFileDefinition : FileDefinition
+        {
+            public BinaryFileDefinition(int seed, int size, DateTimeOffset modified)
+                : base(modified)
+            {
+                Seed = seed;
+                Size = size;
+            }
+
+            public int Seed { get; set; }
+
+            public int Size { get; set; }
+
+            public override FileNode ToNode(string name) => new BinaryFileNode(name, LastWriteTimeUtc, Seed, Size);
+
+            public override FileDefinition Clone() => new BinaryFileDefinition(Seed, Size, LastWriteTimeUtc);
+        }
+    }
+}

--- a/tests/ParallelCompare.Tests/Integration/ComparisonOrchestratorTests.cs
+++ b/tests/ParallelCompare.Tests/Integration/ComparisonOrchestratorTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ParallelCompare.App.Commands;
+using ParallelCompare.App.Services;
+using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.Options;
+using Xunit;
+
+namespace ParallelCompare.Tests.Integration;
+
+public sealed class ComparisonOrchestratorTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+    public ComparisonOrchestratorTests()
+    {
+        Directory.CreateDirectory(_root);
+    }
+
+    [Fact]
+    public async Task RunAsync_StandardComparisonDetectsDifferences()
+    {
+        var left = CreateDirectory("left", new PhysicalFile
+        {
+            RelativePath = "file1.txt",
+            Content = "hello"
+        }, new PhysicalFile
+        {
+            RelativePath = Path.Combine("nested", "file2.txt"),
+            Content = "content"
+        });
+
+        var right = CreateDirectory("right", new PhysicalFile
+        {
+            RelativePath = "file1.txt",
+            Content = "hello"
+        });
+
+        var orchestrator = new ComparisonOrchestrator();
+        var input = new CompareSettingsInput
+        {
+            LeftPath = left,
+            RightPath = right
+        };
+
+        var (result, resolved) = await orchestrator.RunAsync(input, CancellationToken.None);
+
+        resolved.UsesBaseline.Should().BeFalse();
+        result.Summary.LeftOnlyFiles.Should().Be(1);
+        result.Root.Children.Should().Contain(node => node.Name == "nested" && node.Status == ComparisonStatus.LeftOnly);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithBaselineManifestUsesSnapshot()
+    {
+        var left = CreateDirectory("left-baseline", new PhysicalFile
+        {
+            RelativePath = "file.txt",
+            Content = "baseline"
+        });
+
+        var orchestrator = new ComparisonOrchestrator();
+        var input = new CompareSettingsInput
+        {
+            LeftPath = left,
+            RightPath = left
+        };
+
+        var manifestPath = Path.Combine(_root, "baseline.json");
+        await orchestrator.CreateSnapshotAsync(input, manifestPath, CancellationToken.None);
+
+        // Mutate the directory after snapshot.
+        File.WriteAllText(Path.Combine(left, "file.txt"), "changed");
+
+        var compareInput = new CompareSettingsInput
+        {
+            LeftPath = left,
+            BaselinePath = manifestPath
+        };
+
+        var (result, resolved) = await orchestrator.RunAsync(compareInput, CancellationToken.None);
+
+        resolved.UsesBaseline.Should().BeTrue();
+        result.Baseline.Should().NotBeNull();
+        result.Summary.DifferentFiles.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreateSnapshotAsync_WritesManifestWithEntries()
+    {
+        var left = CreateDirectory("snapshot", new PhysicalFile
+        {
+            RelativePath = Path.Combine("sub", "file.txt"),
+            Content = "snapshot"
+        });
+
+        var orchestrator = new ComparisonOrchestrator();
+        var input = new CompareSettingsInput
+        {
+            LeftPath = left,
+            RightPath = left
+        };
+
+        var manifestPath = Path.Combine(_root, "snapshot.json");
+        var manifest = await orchestrator.CreateSnapshotAsync(input, manifestPath, CancellationToken.None);
+
+        File.Exists(manifestPath).Should().BeTrue();
+        manifest.Root.Children.Should().Contain(entry => entry.Name == "sub");
+
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(manifestPath));
+        document.RootElement.GetProperty("root").GetProperty("children").EnumerateArray().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task WatchCommand_RespectsTimeoutCancellation()
+    {
+        var left = CreateDirectory("watch-left", new PhysicalFile
+        {
+            RelativePath = "file.txt",
+            Content = "watch"
+        });
+
+        var right = CreateDirectory("watch-right", new PhysicalFile
+        {
+            RelativePath = "file.txt",
+            Content = "watch"
+        });
+
+        var orchestrator = new ComparisonOrchestrator();
+        var command = new WatchCommand(orchestrator);
+        var settings = new WatchCommandSettings
+        {
+            Left = left,
+            Right = right,
+            TimeoutSeconds = 1
+        };
+
+        var original = Environment.GetEnvironmentVariable("SPECTRE_CONSOLE_DISABLE");
+        Environment.SetEnvironmentVariable("SPECTRE_CONSOLE_DISABLE", "true");
+        try
+        {
+            var exitCode = await command.ExecuteAsync(null!, settings);
+            exitCode.Should().Be(0);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SPECTRE_CONSOLE_DISABLE", original);
+        }
+    }
+
+    private string CreateDirectory(string name, params PhysicalFile[] files)
+    {
+        var directory = Path.Combine(_root, name);
+        Directory.CreateDirectory(directory);
+        foreach (var file in files)
+        {
+            var path = Path.Combine(directory, file.RelativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            if (file.BinarySeed.HasValue)
+            {
+                var data = new byte[file.BinarySize];
+                var random = new Random(file.BinarySeed.Value);
+                random.NextBytes(data);
+                File.WriteAllBytes(path, data);
+            }
+            else
+            {
+                File.WriteAllText(path, file.Content ?? string.Empty);
+            }
+        }
+
+        return directory;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private sealed record PhysicalFile
+    {
+        public required string RelativePath { get; init; }
+        public string? Content { get; init; }
+        public int? BinarySeed { get; init; }
+        public int BinarySize { get; init; } = 256;
+    }
+}

--- a/tests/ParallelCompare.Tests/ParallelCompare.Tests.csproj
+++ b/tests/ParallelCompare.Tests/ParallelCompare.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ParallelCompare.Core\ParallelCompare.Core.csproj" />
+    <ProjectReference Include="..\..\src\ParallelCompare.App\ParallelCompare.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/ParallelCompare.Tests/Reporting/ComparisonResultExporterTests.cs
+++ b/tests/ParallelCompare.Tests/Reporting/ComparisonResultExporterTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ParallelCompare.Core.Comparison;
+using ParallelCompare.Core.Reporting;
+using Xunit;
+
+namespace ParallelCompare.Tests.Reporting;
+
+public sealed class ComparisonResultExporterTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+    public ComparisonResultExporterTests()
+    {
+        Directory.CreateDirectory(_root);
+    }
+
+    [Fact]
+    public async Task WriteJsonAsync_CreatesDirectoryAndWritesPayload()
+    {
+        var exporter = new ComparisonResultExporter();
+        var result = CreateSampleResult();
+        var path = Path.Combine(_root, "exports", "result.json");
+
+        await exporter.WriteJsonAsync(result, path, CancellationToken.None);
+
+        File.Exists(path).Should().BeTrue();
+        var json = await File.ReadAllTextAsync(path);
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.GetProperty("leftPath").GetString().Should().Be(result.LeftPath);
+        document.RootElement.GetProperty("root").GetProperty("children").EnumerateArray().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task WriteSummaryAsync_CreatesDirectoryAndWritesSummary()
+    {
+        var exporter = new ComparisonResultExporter();
+        var result = CreateSampleResult();
+        var path = Path.Combine(_root, "exports", "summary.json");
+
+        await exporter.WriteSummaryAsync(result, path, CancellationToken.None);
+
+        File.Exists(path).Should().BeTrue();
+        var json = await File.ReadAllTextAsync(path);
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.GetProperty("totalFiles").GetInt32().Should().Be(result.Summary.TotalFiles);
+    }
+
+    private static ComparisonResult CreateSampleResult()
+    {
+        var child = new ComparisonNode(
+            "file.txt",
+            "file.txt",
+            ComparisonNodeType.File,
+            ComparisonStatus.Equal,
+            new FileComparisonDetail(10, 10, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, null, null),
+            ImmutableArray<ComparisonNode>.Empty);
+
+        var root = new ComparisonNode(
+            "left",
+            string.Empty,
+            ComparisonNodeType.Directory,
+            ComparisonStatus.Equal,
+            null,
+            ImmutableArray.Create(child));
+
+        var summary = new ComparisonSummary(1, 1, 0, 0, 0, 0);
+        return new ComparisonResult("/left", "/right", root, summary);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+}

--- a/tests/ParallelCompare.Tests/Services/DiffToolLauncherTests.cs
+++ b/tests/ParallelCompare.Tests/Services/DiffToolLauncherTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Diagnostics;
+using FluentAssertions;
+using ParallelCompare.App.Services;
+using Xunit;
+
+namespace ParallelCompare.Tests.Services;
+
+public sealed class DiffToolLauncherTests
+{
+    [Fact]
+    public void TryLaunch_WithoutConfiguredTool_ReturnsFailure()
+    {
+        var launcher = new DiffToolLauncher(static _ => true, new StubProcessRunner());
+        var (success, message) = launcher.TryLaunch(null, "left.txt", "right.txt");
+
+        success.Should().BeFalse();
+        message.Should().Be("No diff tool configured.");
+    }
+
+    [Fact]
+    public void TryLaunch_WhenFilesMissing_ReturnsFailure()
+    {
+        var launcher = new DiffToolLauncher(static _ => false, new StubProcessRunner());
+        var (success, message) = launcher.TryLaunch("tool", "left.txt", "right.txt");
+
+        success.Should().BeFalse();
+        message.Should().Be("Both files must exist to launch the diff tool.");
+    }
+
+    [Fact]
+    public void TryLaunch_WhenProcessStarts_ReturnsSuccess()
+    {
+        var runner = new StubProcessRunner { Result = new Process() };
+        var launcher = new DiffToolLauncher(static _ => true, runner);
+
+        var (success, message) = launcher.TryLaunch("tool", "left.txt", "right.txt");
+
+        success.Should().BeTrue();
+        message.Should().Contain("Launched diff tool");
+        runner.LastStartInfo.Should().NotBeNull();
+        runner.LastStartInfo!.ArgumentList.Should().Contain(new[] { "left.txt", "right.txt" });
+    }
+
+    [Fact]
+    public void TryLaunch_WhenProcessRunnerThrows_ReturnsFailure()
+    {
+        var runner = new StubProcessRunner { ThrowOnStart = true };
+        var launcher = new DiffToolLauncher(static _ => true, runner);
+
+        var (success, message) = launcher.TryLaunch("tool", "left.txt", "right.txt");
+
+        success.Should().BeFalse();
+        message.Should().Contain("Failed to launch diff tool");
+    }
+
+    private sealed class StubProcessRunner : IProcessRunner
+    {
+        public Process? Result { get; init; }
+
+        public bool ThrowOnStart { get; init; }
+
+        public ProcessStartInfo? LastStartInfo { get; private set; }
+
+        public Process? Start(ProcessStartInfo startInfo)
+        {
+            LastStartInfo = startInfo;
+            if (ThrowOnStart)
+            {
+                throw new InvalidOperationException("boom");
+            }
+
+            return Result;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a file system abstraction and update comparison and baseline engines to work with virtual or physical file systems
- make the diff tool launcher injectable via a process runner for easier testing
- add a deterministic test file system, new unit suites, integration coverage, and wire the new test project into the solution
- update the release checklist to reflect the new testing deliverables

## Testing
- `dotnet test --logger:"console;verbosity=minimal"`


------
https://chatgpt.com/codex/tasks/task_e_68db0c82ec8c832abdde6aaa884196b7