### PR TITLE
Fix GitVersion configuration for v6 compatibility

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,8 +3,9 @@ branches:
   main:
     regex: ^main$
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     label: ''
-    is-mainline: true
+    is-main-branch: true
 ignore:
   sha: []


### PR DESCRIPTION
## Summary
- update the main branch settings in GitVersion.yml to use the current schema
- enable GitVersion to calculate versions without JSON parse errors

## Testing
- dotnet-gitversion

------
https://chatgpt.com/codex/tasks/task_e_68db6f2c5a98832abe057d85663ee614