### PR TITLE
Ensure release uploads NuGet package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,5 +54,6 @@ jobs:
           tag_name: v${{ steps.gitversion.outputs.semVer }}
           name: v${{ steps.gitversion.outputs.semVer }}
           generate_release_notes: true
+          files: '**/*.nupkg'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- attach the generated NuGet package to the GitHub release so the artifact is available for download

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68db72e2bc24832a8ca822ce6161a3c2