### PR TITLE
Add provider-based file system resolution for remote URIs

### DIFF
--- a/docs/command-compare.md
+++ b/docs/command-compare.md
@@ -32,6 +32,12 @@ fsequal compare <left> [right]
 
 For the complete option set, run `fsequal compare --help`.
 
+### Remote sources (preview syntax)
+
+Source arguments now accept scheme-prefixed URIs in preparation for Phase 6 remote comparisons. For example, the left and right inputs may be written as `ssh://user@host:/path/to/tree`. The CLI routes these URIs through registered file system providers.
+
+> **Note**: The SSH provider is currently a stub that raises a `NotImplementedException` describing the Phase 6 roadmap. Remote execution is intentionally blocked until the remaining transport and security work ships.
+
 ## Examples
 
 Compare two directories, ignore build output, and open the interactive inspector:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -151,6 +151,10 @@ Exporters run incrementally during interactive sessions to keep reports up to da
    fsequal compare A B --diff "code --diff {left} {right}" --interactive
    ```
 
+## Remote comparisons roadmap
+
+The Phase 6 plan introduces remote file system support so teams can diff workspaces that live behind SSH endpoints without manually syncing directories. The CLI already accepts scheme-prefixed URIs—`fsequal compare ssh://user@host:/srv/app ssh://user@host:/srv/app-next`—and routes them through file system providers. Until the remote transport, authentication, and caching layers land, the bundled SSH provider throws a `NotImplementedException` that points back to this roadmap. Local paths continue to resolve through the physical provider as before.
+
 ## Troubleshooting
 
 - Set `--verbosity trace` to capture detailed diagnostics.

--- a/src/FsEqual.Core/FileSystem/Providers/FileSystemProviderCatalog.cs
+++ b/src/FsEqual.Core/FileSystem/Providers/FileSystemProviderCatalog.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace FsEqual.Core.FileSystem.Providers;
+
+/// <summary>
+/// Maintains the ordered set of file system providers used to resolve comparison sources.
+/// </summary>
+public sealed class FileSystemProviderCatalog
+{
+    private readonly ImmutableArray<IFileSystemProvider> _providers;
+
+    private FileSystemProviderCatalog(ImmutableArray<IFileSystemProvider> providers)
+    {
+        _providers = providers;
+    }
+
+    /// <summary>
+    /// Gets the default catalog containing built-in providers.
+    /// </summary>
+    public static FileSystemProviderCatalog Default { get; } = CreateDefault();
+
+    /// <summary>
+    /// Resolves a source string to a file system and normalized path.
+    /// </summary>
+    /// <param name="source">Source path or URI supplied by the user.</param>
+    /// <returns>The resolved file system information.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no provider can resolve the source.</exception>
+    public FileSystemResolution Resolve(string source)
+    {
+        foreach (var provider in _providers)
+        {
+            if (provider.TryResolve(source, out var resolution))
+            {
+                return resolution;
+            }
+        }
+
+        throw new InvalidOperationException($"No file system provider could resolve source '{source}'.");
+    }
+
+    private static FileSystemProviderCatalog CreateDefault()
+    {
+        var providers = ImmutableArray.Create<IFileSystemProvider>(
+            new SshFileSystemProvider(),
+            new PhysicalFileSystemProvider());
+
+        return new FileSystemProviderCatalog(providers);
+    }
+
+    /// <summary>
+    /// Creates a catalog with the specified providers.
+    /// </summary>
+    /// <param name="providers">Providers ordered by precedence.</param>
+    /// <returns>The catalog instance.</returns>
+    public static FileSystemProviderCatalog Create(IEnumerable<IFileSystemProvider> providers)
+        => new(providers.ToImmutableArray());
+}

--- a/src/FsEqual.Core/FileSystem/Providers/FileSystemResolution.cs
+++ b/src/FsEqual.Core/FileSystem/Providers/FileSystemResolution.cs
@@ -1,0 +1,10 @@
+using FsEqual.Core.FileSystem;
+
+namespace FsEqual.Core.FileSystem.Providers;
+
+/// <summary>
+/// Represents the result of resolving a source into a file system abstraction.
+/// </summary>
+/// <param name="Path">Normalized path consumed by the file system.</param>
+/// <param name="FileSystem">Resolved file system implementation.</param>
+public sealed record FileSystemResolution(string Path, IFileSystem FileSystem);

--- a/src/FsEqual.Core/FileSystem/Providers/IFileSystemProvider.cs
+++ b/src/FsEqual.Core/FileSystem/Providers/IFileSystemProvider.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace FsEqual.Core.FileSystem.Providers;
+
+/// <summary>
+/// Resolves file system abstractions for comparison sources.
+/// </summary>
+public interface IFileSystemProvider
+{
+    /// <summary>
+    /// Attempts to resolve a file system for the specified source path or URI.
+    /// </summary>
+    /// <param name="source">Source path provided by the user.</param>
+    /// <param name="resolution">Resolved file system and normalized path.</param>
+    /// <returns><c>true</c> when the provider handled the source; otherwise, <c>false</c>.</returns>
+    bool TryResolve(string source, [NotNullWhen(true)] out FileSystemResolution? resolution);
+}

--- a/src/FsEqual.Core/FileSystem/Providers/PhysicalFileSystemProvider.cs
+++ b/src/FsEqual.Core/FileSystem/Providers/PhysicalFileSystemProvider.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+namespace FsEqual.Core.FileSystem.Providers;
+
+/// <summary>
+/// Resolves local file system paths to the physical file system implementation.
+/// </summary>
+public sealed class PhysicalFileSystemProvider : IFileSystemProvider
+{
+    /// <inheritdoc />
+    public bool TryResolve(string source, [NotNullWhen(true)] out FileSystemResolution? resolution)
+    {
+        resolution = null;
+
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return false;
+        }
+
+        if (Uri.TryCreate(source, UriKind.Absolute, out var uri))
+        {
+            if (!uri.IsFile)
+            {
+                return false;
+            }
+
+            source = uri.LocalPath;
+        }
+
+        var fullPath = Path.GetFullPath(source);
+        resolution = new FileSystemResolution(fullPath, PhysicalFileSystem.Instance);
+        return true;
+    }
+}

--- a/src/FsEqual.Core/FileSystem/Providers/SshFileSystemProvider.cs
+++ b/src/FsEqual.Core/FileSystem/Providers/SshFileSystemProvider.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace FsEqual.Core.FileSystem.Providers;
+
+/// <summary>
+/// Placeholder SSH provider documenting the remote comparison roadmap.
+/// </summary>
+public sealed class SshFileSystemProvider : IFileSystemProvider
+{
+    private const string RoadmapMessage = "SSH remotes are part of the Phase 6 remote comparison roadmap and are not yet implemented.";
+
+    /// <inheritdoc />
+    public bool TryResolve(string source, [NotNullWhen(true)] out FileSystemResolution? resolution)
+    {
+        resolution = null;
+
+        if (!Uri.TryCreate(source, UriKind.Absolute, out var uri) || !string.Equals(uri.Scheme, "ssh", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        throw new NotImplementedException(RoadmapMessage);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a provider catalog that resolves paths and scheme-prefixed URIs to IFileSystem instances
- keep the physical file system as the default provider and add a stub SSH provider that documents the Phase 6 roadmap
- update option resolution and documentation to surface the new URI syntax and remote comparison plans

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db76c71918832aaf36c107b82fe16c