### PR TITLE
Enhance configuration discovery and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ fsequal watch ./src ./baseline --debounce 500
 fsequal snapshot ./src --output artifacts/baseline.json
 ```
 
+## Configuration discovery
+
+FsEqual automatically resolves configuration files when `--config` is not supplied. The loader searches in the following order:
+
+1. The working directory and each parent for `fsequal.config.json` or `.fsequal/config.json`.
+2. User-level folders such as `$XDG_CONFIG_HOME/fsequal/`, `%APPDATA%/fsequal/`, `%LOCALAPPDATA%/fsequal/`, or `~/.fsequal/`.
+3. Finally, the home directory itself for `fsequal.config.json`.
+
+If a configuration file is found but fails validation (for example, negative thread counts or malformed profiles), the CLI prints each violation so issues can be corrected quickly before rerunning.
+
 ## Command reference
 
 | Command | Description |

--- a/docs/command-compare.md
+++ b/docs/command-compare.md
@@ -24,6 +24,7 @@ fsequal compare <left> [right]
 | `--baseline <path>` | Compares the left tree against a previously captured baseline manifest. |
 | `--json <path>` / `--summary <path>` | Writes detailed or summary JSON reports. |
 | `--export <name>` | Runs an exporter bundle defined in configuration. |
+| `--config <path>` | Overrides automatic discovery of `fsequal.config.json` (see below). |
 | `--diff-tool <path>` | Launches an external diff tool when selecting files in the TUI. |
 | `--profile <name>` | Applies a named configuration profile. |
 | `--interactive` | Opens the Spectre.Console-powered inspector after the initial run. |
@@ -31,6 +32,8 @@ fsequal compare <left> [right]
 | `--timeout <seconds>` | Aborts the run after the specified timeout. |
 
 For the complete option set, run `fsequal compare --help`.
+
+When `--config` is omitted, `fsequal` walks up from the working directory searching for `fsequal.config.json` or `.fsequal/config.json`, then falls back to user directories such as `$XDG_CONFIG_HOME/fsequal/`, `%APPDATA%/fsequal/`, `%LOCALAPPDATA%/fsequal/`, or `~/.fsequal/`. If a configuration file is malformed, the CLI lists each validation error (e.g. invalid thread counts or missing profile objects) before exiting so you know exactly what to fix.
 
 ## Examples
 

--- a/src/FsEqual.App/Services/ComparisonOrchestrator.cs
+++ b/src/FsEqual.App/Services/ComparisonOrchestrator.cs
@@ -102,7 +102,10 @@ public sealed class ComparisonOrchestrator
         CompareSettingsInput input,
         CancellationToken cancellationToken)
     {
-        var configuration = await _configurationLoader.LoadAsync(input.ConfigurationPath, cancellationToken);
+        var configurationPath = string.IsNullOrWhiteSpace(input.ConfigurationPath)
+            ? null
+            : input.ConfigurationPath;
+        var configuration = await _configurationLoader.LoadAsync(configurationPath, cancellationToken);
         var resolved = _resolver.Resolve(input, configuration);
         return resolved with { UsesBaseline = false, BaselineMetadata = null };
     }

--- a/src/FsEqual.Core/Configuration/ConfigurationLoader.cs
+++ b/src/FsEqual.Core/Configuration/ConfigurationLoader.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Text;
 using System.Text.Json;
 
 namespace FsEqual.Core.Configuration;
@@ -22,20 +26,209 @@ public sealed class ConfigurationLoader
     /// <returns>The parsed configuration, or <c>null</c> when the path is empty.</returns>
     public async Task<FsEqualConfiguration?> LoadAsync(string? path, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(path))
+        var resolvedPath = ResolvePath(path);
+        if (resolvedPath is null)
         {
             return null;
         }
 
-        if (!File.Exists(path))
+        await using var stream = File.OpenRead(resolvedPath);
+
+        FsEqualConfiguration config;
+        try
         {
-            throw new FileNotFoundException($"Configuration file not found: {path}", path);
+            config = await JsonSerializer.DeserializeAsync<FsEqualConfiguration>(stream, Options, cancellationToken)
+                ?? new FsEqualConfiguration();
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidDataException($"Configuration file '{resolvedPath}' could not be parsed: {ex.Message}", ex);
         }
 
-        await using var stream = File.OpenRead(path);
-        var config = await JsonSerializer.DeserializeAsync<FsEqualConfiguration>(stream, Options, cancellationToken)
-            ?? new FsEqualConfiguration();
-
+        ValidateConfiguration(config, resolvedPath);
         return config;
     }
+
+    private static string? ResolvePath(string? path)
+    {
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            var absolute = Path.GetFullPath(path);
+            if (!File.Exists(absolute))
+            {
+                throw new FileNotFoundException($"Configuration file not found: {absolute}", absolute);
+            }
+
+            return absolute;
+        }
+
+        return FindDefaultConfiguration();
+    }
+
+    private static string? FindDefaultConfiguration()
+    {
+        var candidates = EnumerateCandidates();
+        foreach (var candidate in candidates)
+        {
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> EnumerateCandidates()
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var current = Directory.GetCurrentDirectory();
+
+        foreach (var ancestor in EnumerateAncestors(current))
+        {
+            foreach (var relative in RelativeSearchPaths)
+            {
+                var candidate = Path.GetFullPath(Path.Combine(ancestor, relative));
+                if (seen.Add(candidate))
+                {
+                    yield return candidate;
+                }
+            }
+        }
+
+        foreach (var fallback in EnumerateFallbacks())
+        {
+            var candidate = Path.GetFullPath(fallback);
+            if (seen.Add(candidate))
+            {
+                yield return candidate;
+            }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateAncestors(string start)
+    {
+        var directory = new DirectoryInfo(start);
+        while (directory is not null)
+        {
+            yield return directory.FullName;
+            directory = directory.Parent;
+        }
+    }
+
+    private static IEnumerable<string> EnumerateFallbacks()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(home))
+        {
+            foreach (var relative in HomeRelativeSearchPaths)
+            {
+                yield return Path.Combine(home, relative);
+            }
+        }
+
+        var xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        if (!string.IsNullOrWhiteSpace(xdgConfigHome))
+        {
+            yield return Path.Combine(xdgConfigHome, "fsequal", "fsequal.config.json");
+        }
+
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        if (!string.IsNullOrWhiteSpace(appData))
+        {
+            yield return Path.Combine(appData, "fsequal", "fsequal.config.json");
+        }
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrWhiteSpace(localAppData))
+        {
+            yield return Path.Combine(localAppData, "fsequal", "fsequal.config.json");
+        }
+    }
+
+    private static void ValidateConfiguration(FsEqualConfiguration configuration, string sourcePath)
+    {
+        var errors = new List<string>();
+
+        if (configuration.Defaults is null)
+        {
+            errors.Add("defaults section must be an object.");
+        }
+        else
+        {
+            CollectValidationErrors(configuration.Defaults, "defaults", errors);
+        }
+
+        if (configuration.Profiles is null)
+        {
+            errors.Add("profiles section must be an object.");
+        }
+        else
+        {
+            foreach (var pair in configuration.Profiles)
+            {
+                if (string.IsNullOrWhiteSpace(pair.Key))
+                {
+                    errors.Add("profiles cannot contain empty names.");
+                    continue;
+                }
+
+                if (pair.Value is null)
+                {
+                    errors.Add($"profile '{pair.Key}' must define an object.");
+                    continue;
+                }
+
+                CollectValidationErrors(pair.Value, $"profile '{pair.Key}'", errors);
+            }
+        }
+
+        if (errors.Count == 0)
+        {
+            return;
+        }
+
+        var builder = new StringBuilder();
+        builder.AppendLine($"Configuration file '{sourcePath}' is invalid:");
+        foreach (var error in errors)
+        {
+            builder.Append(" - ");
+            builder.AppendLine(error);
+        }
+
+        throw new InvalidDataException(builder.ToString().TrimEnd());
+    }
+
+    private static void CollectValidationErrors(object instance, string scope, List<string> errors)
+    {
+        var results = new List<ValidationResult>();
+        if (Validator.TryValidateObject(instance, new ValidationContext(instance), results, validateAllProperties: true))
+        {
+            return;
+        }
+
+        foreach (var result in results)
+        {
+            var message = string.IsNullOrWhiteSpace(result.ErrorMessage)
+                ? "Validation failed."
+                : result.ErrorMessage!;
+            errors.Add($"{scope}: {message}");
+        }
+    }
+
+    private static readonly string[] RelativeSearchPaths =
+    {
+        "fsequal.config.json",
+        Path.Combine(".fsequal", "config.json"),
+        Path.Combine(".fsequal", "fsequal.config.json")
+    };
+
+    private static readonly string[] HomeRelativeSearchPaths =
+    {
+        Path.Combine(".config", "fsequal", "fsequal.config.json"),
+        Path.Combine(".config", "fsequal", "config.json"),
+        Path.Combine(".fsequal", "fsequal.config.json"),
+        Path.Combine(".fsequal", "config.json"),
+        "fsequal.config.json"
+    };
 }

--- a/src/FsEqual.Core/Configuration/FsEqualConfiguration.cs
+++ b/src/FsEqual.Core/Configuration/FsEqualConfiguration.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace FsEqual.Core.Configuration;
@@ -10,12 +11,14 @@ public sealed record FsEqualConfiguration
     /// <summary>
     /// Gets the defaults applied when no profile is specified.
     /// </summary>
+    [Required]
     [JsonPropertyName("defaults")]
     public CompareProfile Defaults { get; init; } = new();
 
     /// <summary>
     /// Gets the set of named profiles that can be resolved by command-line commands.
     /// </summary>
+    [Required]
     [JsonPropertyName("profiles")]
     public Dictionary<string, CompareProfile> Profiles { get; init; } = new(StringComparer.OrdinalIgnoreCase);
 }
@@ -71,12 +74,14 @@ public class CompareProfile
     /// Gets the tolerance, in seconds, for modified timestamps.
     /// </summary>
     [JsonPropertyName("mtimeToleranceSeconds")]
+    [Range(0, double.MaxValue, ErrorMessage = "mtimeToleranceSeconds must be greater than or equal to zero.")]
     public double? MTimeToleranceSeconds { get; init; }
 
     /// <summary>
     /// Gets the maximum number of worker threads to use.
     /// </summary>
     [JsonPropertyName("threads")]
+    [Range(1, int.MaxValue, ErrorMessage = "threads must be greater than or equal to 1.")]
     public int? Threads { get; init; }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- walk up from the working directory and through user config folders to discover `fsequal.config.json` when `--config` is not provided
- validate configuration defaults and profiles with descriptive errors before resolving comparison settings
- document the discovery order and validation feedback in the README and CLI help

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db76bf2afc832a85b07cdb10849f9d