### PR TITLE
Improve watch ignore handling and configurable debounce

### DIFF
--- a/src/FsEqual.App/AssemblyInfo.cs
+++ b/src/FsEqual.App/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("FsEqual.Tests")]

--- a/src/FsEqual.App/Commands/WatchCommandSettings.cs
+++ b/src/FsEqual.App/Commands/WatchCommandSettings.cs
@@ -8,8 +8,14 @@ namespace FsEqual.App.Commands;
 public sealed class WatchCommandSettings : CompareCommandSettings
 {
     /// <summary>
-    /// Gets the debounce interval, in milliseconds, between watch-triggered reruns.
+    /// Gets the optional debounce interval, in milliseconds, between watch-triggered reruns.
+    /// Defaults to <see cref="DefaultDebounceMilliseconds"/> when not specified via CLI or configuration.
     /// </summary>
     [CommandOption("--debounce <MILLISECONDS>")]
-    public int DebounceMilliseconds { get; init; } = 750;
+    public int? DebounceMilliseconds { get; init; }
+
+    /// <summary>
+    /// Gets the default debounce interval applied when neither CLI nor configuration specify a value.
+    /// </summary>
+    public const int DefaultDebounceMilliseconds = 750;
 }

--- a/src/FsEqual.App/FsEqual.App.csproj
+++ b/src/FsEqual.App/FsEqual.App.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.9" />
     <PackageReference Include="Spectre.Console" Version="0.51.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.51.1" />
   </ItemGroup>

--- a/src/FsEqual.App/Rendering/ComparisonConsoleRenderer.cs
+++ b/src/FsEqual.App/Rendering/ComparisonConsoleRenderer.cs
@@ -40,18 +40,20 @@ public static class ComparisonConsoleRenderer
     /// </summary>
     /// <param name="result">Most recent comparison result.</param>
     /// <param name="resolved">Resolved settings used for the run.</param>
-    public static void RenderWatchStatus(ComparisonResult result, ResolvedCompareSettings resolved)
+    /// <param name="lastSuccessfulRun">Timestamp of the last successful comparison execution.</param>
+    public static void RenderWatchStatus(ComparisonResult result, ResolvedCompareSettings resolved, DateTimeOffset lastSuccessfulRun)
     {
         string message;
+        var timestamp = Markup.Escape(lastSuccessfulRun.ToLocalTime().ToString("T"));
 
         if (resolved.UsesBaseline && result.Baseline is { } baseline)
         {
             var manifestName = Path.GetFileName(baseline.ManifestPath);
-            message = $"Watching [bold]{Markup.Escape(result.LeftPath)}[/] against baseline [bold]{Markup.Escape(manifestName)}[/] captured {baseline.CreatedAt:u}.";
+            message = $"Watching [bold]{Markup.Escape(result.LeftPath)}[/] against baseline [bold]{Markup.Escape(manifestName)}[/] captured {baseline.CreatedAt:u}. Last successful comparison at {timestamp}.";
         }
         else
         {
-            message = $"Watching [bold]{Markup.Escape(result.LeftPath)}[/] and [bold]{Markup.Escape(result.RightPath)}[/].";
+            message = $"Watching [bold]{Markup.Escape(result.LeftPath)}[/] and [bold]{Markup.Escape(result.RightPath)}[/]. Last successful comparison at {timestamp}.";
         }
 
         AnsiConsole.MarkupLine($"[grey]{message}[/]");

--- a/src/FsEqual.App/Services/ComparisonOrchestrator.cs
+++ b/src/FsEqual.App/Services/ComparisonOrchestrator.cs
@@ -36,6 +36,7 @@ public sealed class ComparisonOrchestrator
         var additional = algorithms.Length > 1
             ? algorithms.Skip(1).ToImmutableArray()
             : ImmutableArray<string>.Empty;
+        int? debounce = (settings as WatchCommandSettings)?.DebounceMilliseconds;
 
         return new CompareSettingsInput
         {
@@ -62,7 +63,8 @@ public sealed class ComparisonOrchestrator
             Verbosity = settings.Verbosity,
             FailOn = settings.FailOn,
             Timeout = settings.TimeoutSeconds.HasValue ? TimeSpan.FromSeconds(settings.TimeoutSeconds.Value) : null,
-            EnableInteractive = settings.Interactive
+            EnableInteractive = settings.Interactive,
+            DebounceMilliseconds = debounce
         };
     }
 

--- a/src/FsEqual.Core/Configuration/FsEqualConfiguration.cs
+++ b/src/FsEqual.Core/Configuration/FsEqualConfiguration.cs
@@ -138,4 +138,10 @@ public class CompareProfile
     /// </summary>
     [JsonPropertyName("interactiveVerbosity")]
     public string? InteractiveVerbosity { get; init; }
+
+    /// <summary>
+    /// Gets the debounce interval, in milliseconds, to apply when running in watch mode.
+    /// </summary>
+    [JsonPropertyName("debounceMilliseconds")]
+    public int? DebounceMilliseconds { get; init; }
 }

--- a/src/FsEqual.Core/Options/CompareSettingsInput.cs
+++ b/src/FsEqual.Core/Options/CompareSettingsInput.cs
@@ -131,4 +131,9 @@ public sealed record CompareSettingsInput
     /// Gets the verbosity level for interactive logging panes.
     /// </summary>
     public string? InteractiveVerbosity { get; init; }
+
+    /// <summary>
+    /// Gets the debounce interval, in milliseconds, requested for watch mode reruns.
+    /// </summary>
+    public int? DebounceMilliseconds { get; init; }
 }

--- a/src/FsEqual.Core/Options/CompareSettingsResolver.cs
+++ b/src/FsEqual.Core/Options/CompareSettingsResolver.cs
@@ -49,6 +49,9 @@ public sealed class CompareSettingsResolver
         var mode = ParseMode(input.Mode ?? profile?.Mode ?? defaults.Mode);
         var algorithms = ResolveAlgorithms(input, profile, defaults, mode);
         var ignore = MergeArrays(defaults.Ignore, profile?.Ignore, input.IgnorePatterns);
+        var debounce = input.DebounceMilliseconds
+            ?? profile?.DebounceMilliseconds
+            ?? defaults.DebounceMilliseconds;
 
         return new ResolvedCompareSettings
         {
@@ -57,6 +60,7 @@ public sealed class CompareSettingsResolver
             Mode = mode,
             Algorithms = algorithms,
             IgnorePatterns = ignore,
+            WatchDebounceMilliseconds = debounce,
             CaseSensitive = input.CaseSensitive ?? profile?.CaseSensitive ?? defaults.CaseSensitive ?? false,
             FollowSymlinks = input.FollowSymlinks ?? profile?.FollowSymlinks ?? defaults.FollowSymlinks ?? false,
             ModifiedTimeTolerance = input.ModifiedTimeTolerance

--- a/src/FsEqual.Core/Options/ResolvedCompareSettings.cs
+++ b/src/FsEqual.Core/Options/ResolvedCompareSettings.cs
@@ -125,6 +125,11 @@ public sealed record ResolvedCompareSettings
     public BaselineMetadata? BaselineMetadata { get; init; }
 
     /// <summary>
+    /// Gets the debounce interval, in milliseconds, applied when watching for changes.
+    /// </summary>
+    public int? WatchDebounceMilliseconds { get; init; }
+
+    /// <summary>
     /// Gets the file system abstraction used by the comparison engine.
     /// </summary>
     public IFileSystem FileSystem { get; init; } = PhysicalFileSystem.Instance;

--- a/tests/FsEqual.Tests/Commands/WatchCommandTests.cs
+++ b/tests/FsEqual.Tests/Commands/WatchCommandTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using FluentAssertions;
+using FsEqual.App.Commands;
+using FsEqual.Core.Comparison;
+using FsEqual.Core.Configuration;
+using FsEqual.Core.Options;
+using Xunit;
+
+namespace FsEqual.Tests.Commands;
+
+public sealed class WatchCommandTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+    public WatchCommandTests()
+    {
+        Directory.CreateDirectory(_root);
+    }
+
+    [Fact]
+    public void ResolveDebounceInterval_UsesCliValueWhenProvided()
+    {
+        var settings = new WatchCommandSettings
+        {
+            DebounceMilliseconds = 125
+        };
+
+        var resolved = CreateResolved(leftName: "cli-left", rightName: "cli-right");
+
+        var interval = WatchCommand.ResolveDebounceInterval(settings, resolved);
+
+        interval.Should().Be(TimeSpan.FromMilliseconds(125));
+    }
+
+    [Fact]
+    public void ResolveDebounceInterval_FallsBackToResolvedValue()
+    {
+        var settings = new WatchCommandSettings();
+        var resolved = CreateResolved(leftName: "config-left", rightName: "config-right")
+            with
+            {
+                WatchDebounceMilliseconds = 640
+            };
+
+        var interval = WatchCommand.ResolveDebounceInterval(settings, resolved);
+
+        interval.Should().Be(TimeSpan.FromMilliseconds(640));
+    }
+
+    [Fact]
+    public void ResolveDebounceInterval_DefaultsWhenNotSpecified()
+    {
+        var settings = new WatchCommandSettings();
+        var resolved = CreateResolved(leftName: "default-left", rightName: "default-right");
+
+        var interval = WatchCommand.ResolveDebounceInterval(settings, resolved);
+
+        interval.Should().Be(TimeSpan.FromMilliseconds(WatchCommandSettings.DefaultDebounceMilliseconds));
+    }
+
+    [Fact]
+    public void ShouldTriggerChange_SuppressesCliIgnoredPath()
+    {
+        var left = CreateDirectory("cli-ignore-left");
+        var right = CreateDirectory("cli-ignore-right");
+
+        var input = new CompareSettingsInput
+        {
+            LeftPath = left,
+            RightPath = right,
+            IgnorePatterns = ImmutableArray.Create("*.tmp")
+        };
+
+        var resolver = new CompareSettingsResolver();
+        var resolved = resolver.Resolve(input, configuration: null);
+        var matcher = WatchCommand.CreateIgnoreMatcher(resolved)!;
+
+        var ignoredFile = Path.Combine(left, "skip.tmp");
+        WatchCommand.ShouldTriggerChange(left, ignoredFile, null, matcher).Should().BeFalse();
+
+        var includedFile = Path.Combine(left, "keep.txt");
+        WatchCommand.ShouldTriggerChange(left, includedFile, null, matcher).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldTriggerChange_SuppressesConfigIgnoredPath()
+    {
+        var left = CreateDirectory("config-ignore-left");
+        var right = CreateDirectory("config-ignore-right");
+
+        var configuration = new FsEqualConfiguration
+        {
+            Defaults = new CompareProfile
+            {
+                Left = left,
+                Right = right,
+                Ignore = new[] { "*.log" }
+            }
+        };
+
+        var input = new CompareSettingsInput
+        {
+            LeftPath = left,
+            RightPath = right
+        };
+
+        var resolver = new CompareSettingsResolver();
+        var resolved = resolver.Resolve(input, configuration);
+        var matcher = WatchCommand.CreateIgnoreMatcher(resolved)!;
+
+        var ignoredFile = Path.Combine(left, "skip.log");
+        WatchCommand.ShouldTriggerChange(left, ignoredFile, null, matcher).Should().BeFalse();
+
+        var includedFile = Path.Combine(left, "keep.txt");
+        WatchCommand.ShouldTriggerChange(left, includedFile, null, matcher).Should().BeTrue();
+    }
+
+    private ResolvedCompareSettings CreateResolved(string leftName, string rightName)
+    {
+        var left = CreateDirectory(leftName);
+        var right = CreateDirectory(rightName);
+
+        return new ResolvedCompareSettings
+        {
+            LeftPath = left,
+            RightPath = right,
+            Mode = ComparisonMode.Quick
+        };
+    }
+
+    private string CreateDirectory(string name)
+    {
+        var path = Path.Combine(_root, name);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+}

--- a/tests/FsEqual.Tests/Configuration/CompareSettingsResolverTests.cs
+++ b/tests/FsEqual.Tests/Configuration/CompareSettingsResolverTests.cs
@@ -91,4 +91,63 @@ public sealed class CompareSettingsResolverTests
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("Profile 'missing' was not found in the configuration file.");
     }
+
+    [Fact]
+    public void Resolve_WithConfigurationDebounce_UsesConfiguredValue()
+    {
+        var configuration = new FsEqualConfiguration
+        {
+            Defaults = new CompareProfile
+            {
+                Left = "defaults/left",
+                Right = "defaults/right",
+                DebounceMilliseconds = 1500
+            }
+        };
+
+        var input = new CompareSettingsInput
+        {
+            LeftPath = "defaults/left",
+            RightPath = "defaults/right"
+        };
+
+        var resolver = new CompareSettingsResolver();
+        var resolved = resolver.Resolve(input, configuration);
+
+        resolved.WatchDebounceMilliseconds.Should().Be(1500);
+    }
+
+    [Fact]
+    public void Resolve_WithCliDebounce_OverridesConfiguration()
+    {
+        var configuration = new FsEqualConfiguration
+        {
+            Defaults = new CompareProfile
+            {
+                Left = "defaults/left",
+                Right = "defaults/right",
+                DebounceMilliseconds = 2000
+            },
+            Profiles =
+            {
+                ["ci"] = new CompareProfile
+                {
+                    DebounceMilliseconds = 1400
+                }
+            }
+        };
+
+        var input = new CompareSettingsInput
+        {
+            LeftPath = "cli/left",
+            RightPath = "cli/right",
+            Profile = "ci",
+            DebounceMilliseconds = 320
+        };
+
+        var resolver = new CompareSettingsResolver();
+        var resolved = resolver.Resolve(input, configuration);
+
+        resolved.WatchDebounceMilliseconds.Should().Be(320);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure watch command filters ignored paths, uses resolved debounce intervals, and reports last successful comparison
- plumb configurable debounce milliseconds through settings resolver and configuration profile defaults
- extend unit tests for debounce precedence and watch ignore handling across CLI and config inputs

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db76c65f18832aa4f397b49fb9fb7c