### PR TITLE
Add quiet and dry-run CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ fsequal watch ./src ./baseline --debounce 500
 
 # Capture a baseline manifest for regression testing
 fsequal snapshot ./src --output artifacts/baseline.json
+
+# Validate configuration without running the engine
+fsequal compare ./src ./baseline --dry-run
+
+# Produce exports silently for automation
+fsequal compare ./src ./baseline --quiet --summary artifacts/summary.json
 ```
 
 ## Command reference

--- a/docs/command-compare.md
+++ b/docs/command-compare.md
@@ -26,6 +26,8 @@ fsequal compare <left> [right]
 | `--export <name>` | Runs an exporter bundle defined in configuration. |
 | `--diff-tool <path>` | Launches an external diff tool when selecting files in the TUI. |
 | `--profile <name>` | Applies a named configuration profile. |
+| `-q|--quiet` | Suppresses non-essential console output (still writes exports and errors). |
+| `--dry-run` | Validates inputs and configuration without executing the comparison engine. |
 | `--interactive` | Opens the Spectre.Console-powered inspector after the initial run. |
 | `--fail-on <policy>` | Controls the exit code (`any`, `diff`, or `error`). |
 | `--timeout <seconds>` | Aborts the run after the specified timeout. |
@@ -50,4 +52,10 @@ Run in headless mode but still capture a Markdown export bundle defined in confi
 
 ```bash
 fsequal compare ./src ./baseline --export markdown-bundle --no-progress
+```
+
+Validate a configuration and export paths without traversing the file system:
+
+```bash
+fsequal compare ./src ./baseline --dry-run --quiet
 ```

--- a/docs/command-snapshot.md
+++ b/docs/command-snapshot.md
@@ -11,7 +11,7 @@ fsequal snapshot <left> --output <path>
 - `<left>` – Directory to capture.
 - `--output <path>` – Required destination path for the manifest (JSON).
 
-All common options from [`compare`](command-compare.md) still apply. For example, you can provide ignore patterns, algorithms, or profiles to ensure the snapshot reflects the desired configuration.
+All common options from [`compare`](command-compare.md) still apply. For example, you can provide ignore patterns, algorithms, or profiles to ensure the snapshot reflects the desired configuration. The `-q|--quiet` flag suppresses progress messages, and `--dry-run` validates paths and configuration without writing a manifest.
 
 ## Examples
 
@@ -25,4 +25,10 @@ Export to a temporary directory ready for distribution:
 
 ```bash
 fsequal snapshot ./src --output $(mktemp -d)/baseline.json
+```
+
+Verify that configuration and destinations are valid without creating a manifest:
+
+```bash
+fsequal snapshot ./src --output artifacts/baseline.json --dry-run --quiet
 ```

--- a/docs/command-watch.md
+++ b/docs/command-watch.md
@@ -15,6 +15,8 @@ The `<left>` and optional `[right]` arguments match the semantics of `compare`. 
 | Option | Description |
 | --- | --- |
 | `--debounce <milliseconds>` | Waits for the specified quiet period before triggering a rerun (default `750`). |
+| `-q|--quiet` | Minimizes console output between reruns (summaries and trees are skipped). |
+| `--dry-run` | Resolves configuration and validates paths without starting the watch loop. |
 
 All other options from [`compare`](command-compare.md) are available, including exporters, diff tool integration, and interactive mode.
 
@@ -36,4 +38,10 @@ Monitor a directory against a baseline in headless mode but still emit reports:
 
 ```bash
 fsequal watch ./src --baseline artifacts/baseline.json --json artifacts/watch-report.json --summary artifacts/watch-summary.json
+```
+
+Validate inputs prior to starting a long-running watch session:
+
+```bash
+fsequal watch ./src ./baseline --dry-run
 ```

--- a/src/FsEqual.App/Commands/CompareCommandSettings.cs
+++ b/src/FsEqual.App/Commands/CompareCommandSettings.cs
@@ -117,6 +117,12 @@ public class CompareCommandSettings : CommandSettings
     public string? Verbosity { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether console output should be minimized.
+    /// </summary>
+    [CommandOption("-q|--quiet")]
+    public bool Quiet { get; init; }
+
+    /// <summary>
     /// Gets the failure condition expression used to determine the exit code.
     /// </summary>
     [CommandOption("--fail-on")]
@@ -127,6 +133,12 @@ public class CompareCommandSettings : CommandSettings
     /// </summary>
     [CommandOption("--timeout")]
     public int? TimeoutSeconds { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the comparison should validate inputs without executing.
+    /// </summary>
+    [CommandOption("--dry-run")]
+    public bool DryRun { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether the interactive interface should start automatically.

--- a/src/FsEqual.App/Interactive/InteractiveCompareSession.cs
+++ b/src/FsEqual.App/Interactive/InteractiveCompareSession.cs
@@ -836,6 +836,11 @@ public sealed class InteractiveCompareSession
                 .StartAsync("Running comparison...", async _ =>
                 {
                     var run = await _orchestrator.RunAsync(updatedInput, _cancellationToken);
+                    if (run.Result is null)
+                    {
+                        throw new InvalidOperationException("Interactive sessions are not supported during dry runs.");
+                    }
+
                     _result = run.Result;
                     _resolved = run.Resolved;
                     _input = updatedInput;

--- a/src/FsEqual.App/Rendering/ComparisonConsoleRenderer.cs
+++ b/src/FsEqual.App/Rendering/ComparisonConsoleRenderer.cs
@@ -16,8 +16,13 @@ public static class ComparisonConsoleRenderer
     /// Renders the comparison context and summary metrics to the console.
     /// </summary>
     /// <param name="result">Comparison result to render.</param>
-    public static void RenderSummary(ComparisonResult result)
+    public static void RenderSummary(ComparisonResult result, bool quiet = false)
     {
+        if (quiet)
+        {
+            return;
+        }
+
         AnsiConsole.Write(BuildContextPanel(result));
 
         var summary = result.Summary;
@@ -40,8 +45,13 @@ public static class ComparisonConsoleRenderer
     /// </summary>
     /// <param name="result">Most recent comparison result.</param>
     /// <param name="resolved">Resolved settings used for the run.</param>
-    public static void RenderWatchStatus(ComparisonResult result, ResolvedCompareSettings resolved)
+    public static void RenderWatchStatus(ComparisonResult result, ResolvedCompareSettings resolved, bool quiet = false)
     {
+        if (quiet)
+        {
+            return;
+        }
+
         string message;
 
         if (resolved.UsesBaseline && result.Baseline is { } baseline)
@@ -62,8 +72,13 @@ public static class ComparisonConsoleRenderer
     /// </summary>
     /// <param name="result">Comparison result to display.</param>
     /// <param name="maxDepth">Maximum depth to expand within the tree.</param>
-    public static void RenderTree(ComparisonResult result, int maxDepth = 3)
+    public static void RenderTree(ComparisonResult result, int maxDepth = 3, bool quiet = false)
     {
+        if (quiet)
+        {
+            return;
+        }
+
         var tree = new Tree(GetNodeLabel(result.Root));
         BuildTree(tree.AddNode, result.Root, 1, maxDepth);
         AnsiConsole.Write(tree);

--- a/src/FsEqual.Core/Options/CompareSettingsInput.cs
+++ b/src/FsEqual.Core/Options/CompareSettingsInput.cs
@@ -108,6 +108,11 @@ public sealed record CompareSettingsInput
     public string? Verbosity { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether console output should be minimized.
+    /// </summary>
+    public bool Quiet { get; init; }
+
+    /// <summary>
     /// Gets the failure condition expression (e.g., errors, differences).
     /// </summary>
     public string? FailOn { get; init; }
@@ -131,4 +136,9 @@ public sealed record CompareSettingsInput
     /// Gets the verbosity level for interactive logging panes.
     /// </summary>
     public string? InteractiveVerbosity { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the run should validate inputs without executing.
+    /// </summary>
+    public bool DryRun { get; init; }
 }


### PR DESCRIPTION
## Summary
- add `--quiet` and `--dry-run` options across compare, watch, and snapshot commands and propagate them through the orchestrator
- suppress console output in quiet mode and short-circuit engine execution during dry runs
- document the new modes and add an integration test covering orchestrator dry runs

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db76f91968832ab5bf2b47451ef6ed