### PR TITLE
Add live comparison progress output and configurable summary filter

### DIFF
--- a/docs/command-compare.md
+++ b/docs/command-compare.md
@@ -27,10 +27,14 @@ fsequal compare <left> [right]
 | `--diff-tool <path>` | Launches an external diff tool when selecting files in the TUI. |
 | `--profile <name>` | Applies a named configuration profile. |
 | `--interactive` | Opens the Spectre.Console-powered inspector after the initial run. |
+| `--summary-filter <name>` | Chooses which nodes appear in the final tree (e.g. `differences`, `left`, `right`, `errors`, `all`). Defaults to `differences`. |
+| `--no-progress` | Suppresses the live progress panel that streams MB/s, files/s, totals, and pipeline counts. |
 | `--fail-on <policy>` | Controls the exit code (`any`, `diff`, or `error`). |
 | `--timeout <seconds>` | Aborts the run after the specified timeout. |
 
 For the complete option set, run `fsequal compare --help`.
+
+By default the CLI renders a live progress panel that reports left/right throughput in MB/s, files processed per second, total bytes read, and how many files remain in the pipeline. Use `--no-progress` to suppress the panel in CI logs.
 
 ## Examples
 

--- a/docs/command-watch.md
+++ b/docs/command-watch.md
@@ -15,6 +15,7 @@ The `<left>` and optional `[right]` arguments match the semantics of `compare`. 
 | Option | Description |
 | --- | --- |
 | `--debounce <milliseconds>` | Waits for the specified quiet period before triggering a rerun (default `750`). |
+| `--summary-filter <name>` | Same as `compare`; defaults to `differences` so the watch tree only shows interesting nodes. |
 
 All other options from [`compare`](command-compare.md) are available, including exporters, diff tool integration, and interactive mode.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -154,7 +154,8 @@ Exporters run incrementally during interactive sessions to keep reports up to da
 ## Troubleshooting
 
 - Set `--verbosity trace` to capture detailed diagnostics.
-- Use `--no-progress` in CI to avoid control characters in logs.
+- Use `--no-progress` in CI to avoid control characters in logs; otherwise the live panel streams MB/s, files/s, total bytes, and queued files in real time.
+- Switch the final tree with `--summary-filter all|differences|left|right|errors` when you need more or less detail.
 - If diff tools are not discovered automatically, specify the absolute path via `--diff`.
 - When running over network shares, consider `--hash sha256` for stronger verification.
 

--- a/src/FsEqual.App/Commands/CompareCommand.cs
+++ b/src/FsEqual.App/Commands/CompareCommand.cs
@@ -50,8 +50,7 @@ public sealed class CompareCommand : AsyncCommand<CompareCommandSettings>
 
             (var result, var resolved) = settings.NoProgress
                 ? await _orchestrator.RunAsync(input, cancellation.Token)
-                : await AnsiConsole.Status()
-                    .StartAsync("Comparing directories...", async _ => await _orchestrator.RunAsync(input, cancellation.Token));
+                : await ComparisonProgressConsole.RunAsync(_orchestrator, input, cancellation.Token);
 
             ComparisonConsoleRenderer.RenderSummary(result);
 
@@ -61,7 +60,8 @@ public sealed class CompareCommand : AsyncCommand<CompareCommandSettings>
             }
             else
             {
-                ComparisonConsoleRenderer.RenderTree(result);
+                var summaryFilter = InteractiveFilterExtensions.Parse(resolved.SummaryFilter);
+                ComparisonConsoleRenderer.RenderTree(result, summaryFilter);
             }
 
             return DetermineExitCode(resolved.FailOn, result);

--- a/src/FsEqual.App/Commands/CompareCommandSettings.cs
+++ b/src/FsEqual.App/Commands/CompareCommandSettings.cs
@@ -111,6 +111,12 @@ public class CompareCommandSettings : CommandSettings
     public string? ConfigurationPath { get; init; }
 
     /// <summary>
+    /// Gets the summary filter applied when rendering tree output.
+    /// </summary>
+    [CommandOption("--summary-filter")]
+    public string? SummaryFilter { get; init; }
+
+    /// <summary>
     /// Gets the desired verbosity level for console output.
     /// </summary>
     [CommandOption("--verbosity")]

--- a/src/FsEqual.App/Commands/WatchCommand.cs
+++ b/src/FsEqual.App/Commands/WatchCommand.cs
@@ -50,7 +50,9 @@ public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
             };
             Console.CancelKeyPress += handler;
 
-            var resolvedRun = await _orchestrator.RunAsync(input, cancellation.Token);
+            var resolvedRun = settings.NoProgress
+                ? await _orchestrator.RunAsync(input, cancellation.Token)
+                : await ComparisonProgressConsole.RunAsync(_orchestrator, input, cancellation.Token);
 
             if (settings.Interactive)
             {
@@ -211,7 +213,8 @@ public sealed class WatchCommand : AsyncCommand<WatchCommandSettings>
         ComparisonConsoleRenderer.RenderWatchStatus(result, resolved);
         if (!settings.Interactive)
         {
-            ComparisonConsoleRenderer.RenderTree(result, maxDepth: 2);
+            var summaryFilter = InteractiveFilterExtensions.Parse(resolved.SummaryFilter);
+            ComparisonConsoleRenderer.RenderTree(result, summaryFilter, maxDepth: 2);
         }
     }
 }

--- a/src/FsEqual.App/Rendering/ComparisonProgressConsole.cs
+++ b/src/FsEqual.App/Rendering/ComparisonProgressConsole.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FsEqual.App.Services;
+using FsEqual.Core.Options;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace FsEqual.App.Rendering;
+
+/// <summary>
+/// Renders a live progress view while a comparison run executes.
+/// </summary>
+public static class ComparisonProgressConsole
+{
+    /// <summary>
+    /// Executes the comparison with live progress output.
+    /// </summary>
+    /// <param name="orchestrator">Comparison orchestrator to invoke.</param>
+    /// <param name="input">Comparison input describing the run.</param>
+    /// <param name="cancellationToken">Token used to cancel execution.</param>
+    /// <returns>The completed comparison result and resolved settings.</returns>
+    public static async Task<(FsEqual.Core.Comparison.ComparisonResult Result, ResolvedCompareSettings Resolved)> RunAsync(
+        ComparisonOrchestrator orchestrator,
+        CompareSettingsInput input,
+        CancellationToken cancellationToken)
+    {
+        var tracker = new ComparisonProgressTracker();
+        var initial = BuildProgressPanel(tracker.GetSnapshot());
+
+        FsEqual.Core.Comparison.ComparisonResult? result = null;
+        ResolvedCompareSettings? resolved = null;
+
+        await AnsiConsole.Live(initial)
+            .AutoClear(false)
+            .StartAsync(async ctx =>
+            {
+                var runTask = orchestrator.RunAsync(input, cancellationToken, tracker);
+
+                while (!runTask.IsCompleted)
+                {
+                    ctx.UpdateTarget(BuildProgressPanel(tracker.GetSnapshot()));
+                    ctx.Refresh();
+
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
+                    await Task.WhenAny(runTask, Task.Delay(100));
+                }
+
+                var run = await runTask;
+                result = run.Result;
+                resolved = run.Resolved;
+                ctx.UpdateTarget(BuildProgressPanel(tracker.GetSnapshot()));
+                ctx.Refresh();
+            });
+
+        return (result!, resolved!);
+    }
+
+    private static IRenderable BuildProgressPanel(ComparisonProgressSnapshot snapshot)
+    {
+        var table = new Table().Title("[bold]Comparison Progress[/]");
+        table.AddColumn("Metric");
+        table.AddColumn(new TableColumn("Value").RightAligned());
+
+        table.AddRow("Left MB/s", FormatThroughput(snapshot.LeftBytesPerSecond));
+        table.AddRow("Right MB/s", FormatThroughput(snapshot.RightBytesPerSecond));
+        table.AddRow("Files/s", FormatFilesPerSecond(snapshot.FilesPerSecond));
+        table.AddRow("Processed Files", snapshot.CompletedFiles.ToString());
+        table.AddRow("Total Read", FormatBytes(snapshot.TotalBytes));
+        table.AddRow("Pipeline Files", snapshot.PendingFiles.ToString());
+
+        return new Panel(table)
+            .Border(BoxBorder.Rounded)
+            .Padding(1, 0)
+            .BorderColor(Color.Grey);
+    }
+
+    private static string FormatThroughput(double bytesPerSecond)
+    {
+        var mbPerSecond = bytesPerSecond / (1024d * 1024d);
+        return $"{mbPerSecond:0.00} MB/s";
+    }
+
+    private static string FormatFilesPerSecond(double filesPerSecond)
+        => $"{filesPerSecond:0.00}";
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes == 0)
+        {
+            return "0 B";
+        }
+
+        var absValue = Math.Abs((double)bytes);
+        var units = new[] { "B", "KB", "MB", "GB", "TB", "PB" };
+        var unitIndex = 0;
+
+        while (absValue >= 1024 && unitIndex < units.Length - 1)
+        {
+            absValue /= 1024;
+            unitIndex++;
+        }
+
+        var sign = bytes < 0 ? "-" : string.Empty;
+        return $"{sign}{absValue:0.##} {units[unitIndex]}";
+    }
+}

--- a/src/FsEqual.App/Services/ComparisonProgressTracker.cs
+++ b/src/FsEqual.App/Services/ComparisonProgressTracker.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using FsEqual.Core.Comparison;
+
+namespace FsEqual.App.Services;
+
+/// <summary>
+/// Aggregates comparison progress metrics for console rendering.
+/// </summary>
+public sealed class ComparisonProgressTracker : IComparisonProgressSink
+{
+    private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+    private long _leftBytes;
+    private long _rightBytes;
+    private int _discoveredFiles;
+    private int _completedFiles;
+
+    /// <summary>
+    /// Creates a snapshot of the current progress metrics.
+    /// </summary>
+    /// <returns>The immutable snapshot.</returns>
+    public ComparisonProgressSnapshot GetSnapshot()
+    {
+        var elapsed = _stopwatch.Elapsed;
+        var leftBytes = Interlocked.Read(ref _leftBytes);
+        var rightBytes = Interlocked.Read(ref _rightBytes);
+        var discovered = Volatile.Read(ref _discoveredFiles);
+        var completed = Volatile.Read(ref _completedFiles);
+
+        var seconds = Math.Max(elapsed.TotalSeconds, 0.001);
+        var leftRate = leftBytes / seconds;
+        var rightRate = rightBytes / seconds;
+        var filesPerSecond = completed / seconds;
+
+        return new ComparisonProgressSnapshot(
+            elapsed,
+            leftBytes,
+            rightBytes,
+            discovered,
+            completed,
+            leftRate,
+            rightRate,
+            filesPerSecond);
+    }
+
+    /// <inheritdoc />
+    public void FileDiscovered(string relativePath, long? leftSize, long? rightSize)
+        => Interlocked.Increment(ref _discoveredFiles);
+
+    /// <inheritdoc />
+    public void FileCompleted(string relativePath, ComparisonStatus status)
+        => Interlocked.Increment(ref _completedFiles);
+
+    /// <inheritdoc />
+    public void BytesRead(ComparisonSide side, long bytes)
+    {
+        if (bytes <= 0)
+        {
+            return;
+        }
+
+        if (side == ComparisonSide.Left)
+        {
+            Interlocked.Add(ref _leftBytes, bytes);
+        }
+        else
+        {
+            Interlocked.Add(ref _rightBytes, bytes);
+        }
+    }
+}
+
+/// <summary>
+/// Represents a snapshot of comparison progress metrics.
+/// </summary>
+/// <param name="Elapsed">Elapsed time since the comparison started.</param>
+/// <param name="LeftBytes">Total bytes read from the left input.</param>
+/// <param name="RightBytes">Total bytes read from the right input.</param>
+/// <param name="DiscoveredFiles">Number of files discovered so far.</param>
+/// <param name="CompletedFiles">Number of files processed so far.</param>
+/// <param name="LeftBytesPerSecond">Bytes per second read from the left input.</param>
+/// <param name="RightBytesPerSecond">Bytes per second read from the right input.</param>
+/// <param name="FilesPerSecond">Files processed per second.</param>
+public readonly record struct ComparisonProgressSnapshot(
+    TimeSpan Elapsed,
+    long LeftBytes,
+    long RightBytes,
+    int DiscoveredFiles,
+    int CompletedFiles,
+    double LeftBytesPerSecond,
+    double RightBytesPerSecond,
+    double FilesPerSecond)
+{
+    /// <summary>
+    /// Gets the total bytes read across both inputs.
+    /// </summary>
+    public long TotalBytes => LeftBytes + RightBytes;
+
+    /// <summary>
+    /// Gets the number of files that have been discovered but not yet processed.
+    /// </summary>
+    public int PendingFiles => Math.Max(0, DiscoveredFiles - CompletedFiles);
+}

--- a/src/FsEqual.Core/Baselines/BaselineComparisonOptions.cs
+++ b/src/FsEqual.Core/Baselines/BaselineComparisonOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading;
+using FsEqual.Core.Comparison;
 using FsEqual.Core.FileSystem;
 using FsEqual.Core.Options;
 
@@ -50,6 +51,11 @@ public sealed record BaselineComparisonOptions
     /// Gets the comparison mode that controls how files and directories are evaluated.
     /// </summary>
     public ComparisonMode Mode { get; init; }
+
+    /// <summary>
+    /// Gets the progress sink notified as files are processed.
+    /// </summary>
+    public IComparisonProgressSink? ProgressSink { get; init; }
 
     /// <summary>
     /// Gets the token used to observe cancellation requests during the comparison.

--- a/src/FsEqual.Core/Comparison/Hashing/FileHashCalculator.cs
+++ b/src/FsEqual.Core/Comparison/Hashing/FileHashCalculator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Hashing;
@@ -13,50 +14,87 @@ public sealed class FileHashCalculator
     public IReadOnlyDictionary<HashAlgorithmType, string> ComputeHashes(
         IFileEntry file,
         IEnumerable<HashAlgorithmType> algorithms,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IComparisonProgressSink? progressSink = null,
+        ComparisonSide side = ComparisonSide.Left)
     {
         var result = new Dictionary<HashAlgorithmType, string>();
 
         foreach (var algorithm in algorithms)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            result[algorithm] = ComputeHash(file, algorithm);
+            result[algorithm] = ComputeHash(file, algorithm, progressSink, side);
         }
 
         return result;
     }
 
-    private string ComputeHash(IFileEntry file, HashAlgorithmType algorithm)
+    private string ComputeHash(
+        IFileEntry file,
+        HashAlgorithmType algorithm,
+        IComparisonProgressSink? progressSink,
+        ComparisonSide side)
     {
         return algorithm switch
         {
-            HashAlgorithmType.Crc32 => ComputeUsingIncremental(file, () => new Crc32()),
-            HashAlgorithmType.Md5 => ComputeUsingHashAlgorithm(file, MD5.Create),
-            HashAlgorithmType.Sha256 => ComputeUsingHashAlgorithm(file, SHA256.Create),
-            HashAlgorithmType.XxHash64 => ComputeUsingIncremental(file, () => new XxHash64()),
+            HashAlgorithmType.Crc32 => ComputeUsingIncremental(file, () => new Crc32(), progressSink, side),
+            HashAlgorithmType.Md5 => ComputeUsingHashAlgorithm(file, MD5.Create, progressSink, side),
+            HashAlgorithmType.Sha256 => ComputeUsingHashAlgorithm(file, SHA256.Create, progressSink, side),
+            HashAlgorithmType.XxHash64 => ComputeUsingIncremental(file, () => new XxHash64(), progressSink, side),
             _ => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null)
         };
     }
 
-    private static string ComputeUsingHashAlgorithm(IFileEntry file, Func<HashAlgorithm> factory)
+    private static string ComputeUsingHashAlgorithm(
+        IFileEntry file,
+        Func<HashAlgorithm> factory,
+        IComparisonProgressSink? progressSink,
+        ComparisonSide side)
     {
         using var algorithm = factory();
         using var stream = file.OpenRead();
-        var hash = algorithm.ComputeHash(stream);
-        return Convert.ToHexString(hash).ToLowerInvariant();
+        var buffer = ArrayPool<byte>.Shared.Rent(8192);
+        try
+        {
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                algorithm.TransformBlock(buffer, 0, read, null, 0);
+                progressSink?.BytesRead(side, read);
+            }
+
+            algorithm.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+            return Convert.ToHexString(algorithm.Hash!).ToLowerInvariant();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 
-    private static string ComputeUsingIncremental(IFileEntry file, Func<NonCryptographicHashAlgorithm> factory)
+    private static string ComputeUsingIncremental(
+        IFileEntry file,
+        Func<NonCryptographicHashAlgorithm> factory,
+        IComparisonProgressSink? progressSink,
+        ComparisonSide side)
     {
         var algorithm = factory();
         try
         {
             using var stream = file.OpenRead();
-            var buffer = new byte[8192];
-            int read;
-            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+            var buffer = ArrayPool<byte>.Shared.Rent(8192);
+            try
             {
-                algorithm.Append(buffer.AsSpan(0, read));
+                int read;
+                while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    algorithm.Append(buffer.AsSpan(0, read));
+                    progressSink?.BytesRead(side, read);
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
             }
 
             Span<byte> destination = stackalloc byte[algorithm.HashLengthInBytes];

--- a/src/FsEqual.Core/Comparison/IComparisonProgressSink.cs
+++ b/src/FsEqual.Core/Comparison/IComparisonProgressSink.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace FsEqual.Core.Comparison;
+
+/// <summary>
+/// Identifies the side of the comparison that performed an IO operation.
+/// </summary>
+public enum ComparisonSide
+{
+    /// <summary>
+    /// Data read from the left input.
+    /// </summary>
+    Left,
+
+    /// <summary>
+    /// Data read from the right input.
+    /// </summary>
+    Right
+}
+
+/// <summary>
+/// Receives streaming progress updates during comparison execution.
+/// </summary>
+public interface IComparisonProgressSink
+{
+    /// <summary>
+    /// Notifies the sink that a file has been discovered and queued for processing.
+    /// </summary>
+    /// <param name="relativePath">Path relative to the comparison root.</param>
+    /// <param name="leftSize">Size of the left file, when available.</param>
+    /// <param name="rightSize">Size of the right file, when available.</param>
+    void FileDiscovered(string relativePath, long? leftSize, long? rightSize);
+
+    /// <summary>
+    /// Notifies the sink that a file has finished processing.
+    /// </summary>
+    /// <param name="relativePath">Path relative to the comparison root.</param>
+    /// <param name="status">Final comparison status for the file.</param>
+    void FileCompleted(string relativePath, ComparisonStatus status);
+
+    /// <summary>
+    /// Records the number of bytes read from one side of the comparison.
+    /// </summary>
+    /// <param name="side">Side that performed the read.</param>
+    /// <param name="bytes">Number of bytes read.</param>
+    void BytesRead(ComparisonSide side, long bytes);
+}

--- a/src/FsEqual.Core/Configuration/FsEqualConfiguration.cs
+++ b/src/FsEqual.Core/Configuration/FsEqualConfiguration.cs
@@ -104,6 +104,12 @@ public class CompareProfile
     public string? ExportFormat { get; init; }
 
     /// <summary>
+    /// Gets the summary filter applied when rendering console output.
+    /// </summary>
+    [JsonPropertyName("summaryFilter")]
+    public string? SummaryFilter { get; init; }
+
+    /// <summary>
     /// Gets a value indicating whether progress output should be suppressed.
     /// </summary>
     [JsonPropertyName("noProgress")]

--- a/src/FsEqual.Core/Options/CompareSettingsInput.cs
+++ b/src/FsEqual.Core/Options/CompareSettingsInput.cs
@@ -83,6 +83,11 @@ public sealed record CompareSettingsInput
     public string? ExportFormat { get; init; }
 
     /// <summary>
+    /// Gets the summary filter applied when rendering console trees.
+    /// </summary>
+    public string? SummaryFilter { get; init; }
+
+    /// <summary>
     /// Gets a value indicating whether progress output should be suppressed.
     /// </summary>
     public bool NoProgress { get; init; }

--- a/src/FsEqual.Core/Options/CompareSettingsResolver.cs
+++ b/src/FsEqual.Core/Options/CompareSettingsResolver.cs
@@ -67,6 +67,7 @@ public sealed class CompareSettingsResolver
             JsonReportPath = input.JsonReportPath ?? profile?.JsonReport ?? defaults.JsonReport,
             SummaryReportPath = input.SummaryReportPath ?? profile?.SummaryReport ?? defaults.SummaryReport,
             ExportFormat = input.ExportFormat ?? profile?.ExportFormat ?? defaults.ExportFormat,
+            SummaryFilter = input.SummaryFilter ?? profile?.SummaryFilter ?? defaults.SummaryFilter ?? "differences",
             NoProgress = input.NoProgress || profile?.NoProgress == true || defaults.NoProgress == true,
             DiffTool = input.DiffTool ?? profile?.DiffTool ?? defaults.DiffTool,
             Verbosity = input.Verbosity ?? profile?.Verbosity ?? defaults.Verbosity,

--- a/src/FsEqual.Core/Options/ComparisonOptions.cs
+++ b/src/FsEqual.Core/Options/ComparisonOptions.cs
@@ -95,6 +95,11 @@ public sealed record ComparisonOptions
     public IComparisonUpdateSink? UpdateSink { get; init; }
 
     /// <summary>
+    /// Gets the progress sink notified as the comparison executes.
+    /// </summary>
+    public IComparisonProgressSink? ProgressSink { get; init; }
+
+    /// <summary>
     /// Gets the cancellation token observed during execution.
     /// </summary>
     public CancellationToken CancellationToken { get; init; } = CancellationToken.None;

--- a/src/FsEqual.Core/Options/ResolvedCompareSettings.cs
+++ b/src/FsEqual.Core/Options/ResolvedCompareSettings.cs
@@ -75,6 +75,11 @@ public sealed record ResolvedCompareSettings
     public string? ExportFormat { get; init; }
 
     /// <summary>
+    /// Gets the summary filter applied when rendering console trees.
+    /// </summary>
+    public string? SummaryFilter { get; init; }
+
+    /// <summary>
     /// Gets a value indicating whether progress output should be suppressed.
     /// </summary>
     public bool NoProgress { get; init; }

--- a/tests/FsEqual.Tests/Configuration/CompareSettingsResolverTests.cs
+++ b/tests/FsEqual.Tests/Configuration/CompareSettingsResolverTests.cs
@@ -56,6 +56,7 @@ public sealed class CompareSettingsResolverTests
         resolved.Algorithms.Should().Contain(new[] { HashAlgorithmType.Crc32, HashAlgorithmType.XxHash64 });
         resolved.IgnorePatterns.Should().BeEquivalentTo(new[] { "*.tmp", "*.log", "build/*" });
         resolved.Threads.Should().Be(8);
+        resolved.SummaryFilter.Should().Be("differences");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add a progress sink abstraction and wire it through comparison engines to report file discovery, completion, and IO throughput
- show a live comparison progress panel with MB/s, files/s, processed counts, and pipeline depth when progress output is enabled
- introduce a configurable summary filter that defaults CLI tree output to differences and honor the setting across compare/watch commands

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68dcd622ca00832aadf717f3a98a4fb2